### PR TITLE
Fix due to change in underling Android library naming

### DIFF
--- a/android/src/main/java/com/appcuesreactnativesdk/AppcuesReactNativeSdkModule.kt
+++ b/android/src/main/java/com/appcuesreactnativesdk/AppcuesReactNativeSdkModule.kt
@@ -19,8 +19,7 @@ class AppcuesReactNativeSdkModule(reactContext: ReactApplicationContext) : React
         val context = reactApplicationContextIfActiveOrWarn
         val activity = currentActivity
         if (context != null && activity != null) {
-          implementation = Appcues.Builder(context, accountID, applicationID)
-            .logging(Appcues.LoggingLevel.BASIC).build()
+          implementation = Appcues.Builder(context, accountID, applicationID).build()
         }
     }
 


### PR DESCRIPTION
The log level `BASIC` no longer exists and led to a compile error on the Android react native app - went ahead and removed this for now.  We have a future task to revisit the init options to provide better support from the react native side.  But for now, it can use the default init options.