### PR TITLE
Update package publishing to be public

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,8 @@
   },
   "homepage": "https://github.com/appcues/appcues-react-native-module#readme",
   "publishConfig": {
-    "registry": "https://registry.npmjs.org/"
+    "registry": "https://registry.npmjs.org/",
+    "access": "public"
   },
   "devDependencies": {
     "@babel/core": "^7.12.10",


### PR DESCRIPTION
One more thing that's necessary for a public vs private package: https://github.com/release-it/release-it/blob/master/docs/npm.md#public-scoped-packages