### PR TITLE
Pin iOS SDK pod version + package version bump

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,11 +81,9 @@ jobs:
       - restore_cache:
           keys:
             - dependencies-{{ checksum "package.json" }}
-            - dependencies-
       - restore_cache:
           keys:
             - dependencies-example-{{ checksum "example/package.json" }}
-            - dependencies-example-
       - run:
           name: Install dependencies
           command: |

--- a/README.md
+++ b/README.md
@@ -32,15 +32,12 @@ Native Module to bridge the native Appcues SDKs in a React Native application.
    # OR
    yarn add @appcues/react-native
    ```
-2. **[⚠️ BETA ONLY]** Add the pod to your ios projects Podfile
-    ```rb
-    # needs to be explicitly included here until 1.0.0 is released to be able to find the prerelease versions.
-    pod 'Appcues', '1.0.0-beta.4'
-    ```
-3. Under your application's `ios` folder, run
+2. Under your application's `ios` folder, run
    ```sh
    pod install
    ```
+
+Note: You do not need to manually update your Podfile to add Appcues.
 
 ### One Time Setup
 

--- a/appcues-react-native.podspec
+++ b/appcues-react-native.podspec
@@ -16,5 +16,6 @@ Pod::Spec.new do |s|
   s.source_files = "ios/**/*.{h,m,mm,swift}"
 
   s.dependency "React-Core"
-  s.dependency "Appcues"
+  # NOTE: remove the specific version requirement once 1.0.0 is published
+  s.dependency "Appcues", "1.0.0-beta.4"
 end

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -11,9 +11,6 @@ target 'AppcuesReactNativeExample' do
     # to enable hermes on iOS, change `false` to `true` and then install pods
     :hermes_enabled => false,
   )
-
-  # needs to be explicitly included here until 1.0.0 is released to be able to find the prerelease versions.
-  pod 'Appcues', '1.0.0-beta.4'
   
   # Enables Flipper.
   #

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1,7 +1,7 @@
 PODS:
   - Appcues (1.0.0-beta.4)
   - appcues-react-native (1.0.0-beta.1):
-    - Appcues
+    - Appcues (= 1.0.0-beta.4)
     - React-Core
   - boost (1.76.0)
   - CocoaAsyncSocket (7.6.5)
@@ -364,7 +364,6 @@ PODS:
     - Yoga (~> 1.14)
 
 DEPENDENCIES:
-  - Appcues (= 1.0.0-beta.4)
   - "appcues-react-native (from `../node_modules/@appcues/react-native`)"
   - boost (from `../node_modules/react-native/third-party-podspecs/boost.podspec`)
   - DoubleConversion (from `../node_modules/react-native/third-party-podspecs/DoubleConversion.podspec`)
@@ -518,7 +517,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   Appcues: b9656ff8a85985f3a3feaa5728c71f7ce7f164b5
-  appcues-react-native: 11ee1685a73b1a0373a7ca1ee0e26484079c28d3
+  appcues-react-native: 44ad06dba1d86098c4da4e425f04f56c5a4b06a3
   boost: a7c83b31436843459a1961bfd74b96033dc77234
   CocoaAsyncSocket: 065fd1e645c7abab64f7a6a2007a48038fdc6a99
   DoubleConversion: 831926d9b8bf8166fd87886c4abab286c2422662
@@ -569,6 +568,6 @@ SPEC CHECKSUMS:
   Yoga: 6671cf077f614314c22fd09ddf87d7abeee64e96
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a
 
-PODFILE CHECKSUM: 57c8cdf27feb51eafc005c4db7b35c73e23ce0cb
+PODFILE CHECKSUM: c52f44807b8deff86692733be551cd582cf7b712
 
 COCOAPODS: 1.11.3

--- a/example/package.json
+++ b/example/package.json
@@ -1,7 +1,7 @@
 {
   "name": "appcues-react-native-example",
   "description": "Example app for appcues-react-native",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "private": true,
   "scripts": {
     "android": "react-native run-android",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@appcues/react-native",
-  "version": "1.0.0-beta.1",
+  "version": "1.0.0-beta.2",
   "description": "Appcues React Native Module",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",


### PR DESCRIPTION
Like we discussed, this should fix the expo build issue.

Bumping the version for a new release (also has the Android update to beta ~4~ **6** in #41). I'll make a release script based off what I do for this release.