### PR TITLE
Add docs for Expo workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Appcues.screen('Contact Details', {'Contact Reference': 'abc'})
 
 ## 📝 Documentation
 
-Full documentation is available at https://docs.appcues.com/
+More technical documentation about this module (including instruction for usage with Expo Bare and Managed workflow apps) is available in the [`docs` directory](https://github.com/appcues/appcues-react-native-module/tree/main/docs). Full documentation is available at https://docs.appcues.com/
 
 ## 🎬 Examples
 

--- a/docs/ExpoBareWorkflow.md
+++ b/docs/ExpoBareWorkflow.md
@@ -1,0 +1,25 @@
+# Using Appcues React Native with the Expo Bare Workflow
+
+The Appcues React Native module can be easily integrated into an app using the Expo Bare Workflow.
+
+## Installation and Setup
+
+```sh
+$ expo install @appcues/react-native
+```
+
+```js
+import * as Appcues from '@appcues/react-native';
+
+Appcues.setup('APPCUES_ACCOUNT_ID', 'APPCUES_APPLICATION_ID');
+
+Appcues.identify('my-user-id');
+
+Appcues.screen('My Screen Name');
+```
+
+## Usage with Expo Go
+
+If you use the Expo Go app to run your bare project, review the [Using Expo Go in Bare Workflow])https://docs.expo.dev/bare/using-expo-client/) Expo doc. Specifically, consider following the wrapper approach that checks if `NativeModules.AppcuesReactNative` exists and falls back to a no-op or `console.log`. See the code snippet in the [Expo Managed Workflow doc](https://github.com/appcues/appcues-react-native-module/blob/main/docs/ExpoManagedWorkflow.md).
+
+The Appcues SDK will not function in the Expo Go app, but would work when you deploy your bare app.

--- a/docs/ExpoManagedWorkflow.md
+++ b/docs/ExpoManagedWorkflow.md
@@ -1,0 +1,106 @@
+# Using Appcues React Native with the Expo Managed Workflow
+
+The Appcues React Native module can be integrated into an app using the Expo Manaaged Workflow using a simple wrapper. Testing Appcues functionality requires an Expo development build.
+
+## Installation and Setup
+
+```sh
+$ expo install @appcues/react-native
+```
+
+### Wrapping the Appcues SDK
+
+To allow your project to continue to work with the Expo Go app, create a wrapper around the Appcues React Native module that only invokes the Appcues SDK when it's available and otherwise falls back to a `console.log` that allows you to verify your calls to the wrapper are being made in the correct places.
+
+Create a file `AppcuesWrapper.js` that wraps the `NativeModule`:
+
+```js
+import { NativeModules } from 'react-native';
+
+// Get native module or use fallback object
+const AppcuesWrapper = NativeModules.AppcuesReactNative ?? {
+  setup: (accountID, applicationID, options) => { console.log(`Appcues.setup(${accountID}, ${applicationID}, ${JSON.stringify(options)})`) },
+  identify: (userID, properties) => { console.log(`Appcues.identify(${userID}, ${JSON.stringify(properties)})`) },
+  reset: () => { console.log(`Appcues.reset()`) },
+  anonymous: () => { console.log(`Appcues.anonymous()`) },
+  group: (groupID, properties) => { console.log(`Appcues.group(${groupID}, ${JSON.stringify(properties)}`) },
+  screen: (title, properties) => { console.log(`Appcues.screen(${title}, ${JSON.stringify(properties)})`) },
+  track: (name, properties) => { console.log(`Appcues.track(${name}, ${JSON.stringify(properties)})`) },
+  show: (experienceID) => { console.log(`Appcues.show(${experienceID})`) },
+  debug: () => { console.log(`Appcues.debug()`) },
+  didHandleURL: (url) => { console.log(`Appcues.didHandleURL(${url})`); return false },
+};
+
+export function setup(accountID, applicationID, options) {
+  AppcuesWrapper.setup(accountID, applicationID, options);
+}
+
+export function identify(userID, properties) {
+  AppcuesWrapper.identify(userID, properties);
+}
+
+export function reset() {
+  AppcuesWrapper.reset();
+}
+
+export function anonymous() {
+  AppcuesWrapper.anonymous();
+}
+
+export function group(groupID, properties) {
+  AppcuesWrapper.group(groupID, properties);
+}
+
+export function screen(title, properties) {
+  AppcuesWrapper.screen(title, properties);
+}
+
+export function track(name, properties) {
+  AppcuesWrapper.track(name, properties);
+}
+
+export function show(experienceID) {
+  AppcuesWrapper.show(experienceID);
+}
+
+export function debug() {
+  AppcuesWrapper.debug();
+}
+
+export async function didHandleURL(url) {
+  return await AppcuesWrapper.didHandleURL(url);
+}
+```
+
+### Usage
+
+Instead of importing from `@appcues/react-native` directly, reference the `AppcuesWrapper`:
+
+```js
+ import * as AppcuesWrapper from './AppcuesWrapper';
+ AppcuesWrapper.setup('APPCUES_ACCOUNT_ID', 'APPCUES_APPLICATION_ID');
+ 
+ AppcuesWrapper.identify('my-user-id');
+ 
+ AppcuesWrapper.screen('My Screen Name');
+ ```
+
+### Create a Development Build
+
+A development build is necessary to use actually use the real Appcues SDK functionality. The [Getting Started](https://docs.expo.dev/development/getting-started) guide provided by Expo is a comprehensive reference, but the minimal steps are described here:
+
+```sh
+ $ expo install expo-dev-client
+ 
+ # ios
+ $ eas device:create # register test devices onto ad hoc provisioning profile
+ $ eas build --profile development --platform ios
+ 
+ # android
+ eas build --profile development --platform android
+ 
+ # Install the build on a device, then:
+ $ expo start --dev-client
+ 
+ # Then scan the QR code to open on the device
+ ```

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -12,7 +12,8 @@ const LINKING_ERROR =
   `The package 'appcues-react-native' doesn't seem to be linked. Make sure: \n\n` +
   Platform.select({ ios: "- You have run 'pod install'\n", default: '' }) +
   '- You rebuilt the app after installing the package\n' +
-  '- You are not using Expo managed workflow\n';
+  '- You are not using Expo managed workflow\n' +
+  'If you are using the Expo managed workflow, please refer to the Appcues React Native module documentation for Expo.';
 
 const AppcuesReactNative = NativeModules.AppcuesReactNative
   ? NativeModules.AppcuesReactNative


### PR DESCRIPTION
These docs aren't sophisticated, but they're a start. Added the note in README.md for anyone `ctrl+f`ing for Expo.

I also updated the error message that you'd see if you try integrating the module in an expo project without the wrapper.