### PR TITLE
📝 Update Expo managed workflow snippet

### DIFF
--- a/docs/ExpoManagedWorkflow.md
+++ b/docs/ExpoManagedWorkflow.md
@@ -32,7 +32,7 @@ const AppcuesWrapper = NativeModules.AppcuesReactNative ?? {
 };
 
 export function setup(accountID, applicationID, options) {
-  AppcuesWrapper.setup(accountID, applicationID, options);
+  AppcuesWrapper.setup(accountID, applicationID, options, { _applicationFramework: 'expo' });
 }
 
 export function identify(userID, properties) {


### PR DESCRIPTION
SDK 1.1 includes a fourth parameter, `additionalAutoProperties` that must be included. I’ve included a default `_applicationFramework` value, but it’s not strictly required—an empty object would suffice.