### PR TITLE
Remove the ⬆️ emoji from the commit filter

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -77,7 +77,7 @@ case "$response" in
 esac
 
 # get the commits since the last release, filtering ones that aren't relevant.
-changelog=$(git log --pretty=format:"- [%as] %s (%h)" $(git describe --tags --abbrev=0 @^)..@ --abbrev=7 | sed '/[🔧🎬⬆️📸✅💡📝🗃]/d')
+changelog=$(git log --pretty=format:"- [%as] %s (%h)" $(git describe --tags --abbrev=0 @^)..@ --abbrev=7 | sed '/[🔧🎬📸✅💡📝🗃]/d')
 tempFile=$(mktemp)
 # write changelog to temp file.
 echo "$changelog" >> $tempFile


### PR DESCRIPTION
In this repo, the ⬆️ is a meaningful commit for the release notes, since it's typically the relevant item about the underlying native dependency update. Taking this out of the filter for the future.