### PR TITLE
Remove usage of lateinit on native SDK reference to avoid unexpected crash issues

### DIFF
--- a/android/src/main/java/com/appcuesreactnative/AppcuesReactNativeModule.kt
+++ b/android/src/main/java/com/appcuesreactnative/AppcuesReactNativeModule.kt
@@ -14,7 +14,7 @@ import kotlinx.coroutines.launch
 
 class AppcuesReactNativeModule(reactContext: ReactApplicationContext) : ReactContextBaseJavaModule(reactContext) {
 
-    private lateinit var implementation: Appcues
+    private var implementation: Appcues? = null
 
     private val mainScope = CoroutineScope(Dispatchers.Main)
 
@@ -138,38 +138,38 @@ class AppcuesReactNativeModule(reactContext: ReactApplicationContext) : ReactCon
 
     @ReactMethod
     fun identify(userID: String, properties: ReadableMap? = null) {
-        implementation.identify(userID, properties?.toHashMap())
+        implementation?.identify(userID, properties?.toHashMap())
     }
 
     @ReactMethod
     fun reset() {
-        implementation.reset()
+        implementation?.reset()
     }
 
     @ReactMethod
     fun anonymous() {
-        implementation.anonymous()
+        implementation?.anonymous()
     }
 
     @ReactMethod
     fun group(groupID: String?, properties: ReadableMap? = null) {
-        implementation.group(groupID, properties?.toHashMap())
+        implementation?.group(groupID, properties?.toHashMap())
     }
 
     @ReactMethod
     fun screen(title: String, properties: ReadableMap? = null) {
-        implementation.screen(title, properties?.toHashMap())
+        implementation?.screen(title, properties?.toHashMap())
     }
 
     @ReactMethod
     fun track(name: String, properties: ReadableMap? = null) {
-        implementation.track(name, properties?.toHashMap())
+        implementation?.track(name, properties?.toHashMap())
     }
 
     @ReactMethod
     fun show(experienceID: String, promise: Promise) {
         mainScope.launch {
-            val success = implementation.show(experienceID)
+            val success = implementation?.show(experienceID) ?: false
             if (success) {
                 promise.resolve(null)
             } else {
@@ -181,7 +181,7 @@ class AppcuesReactNativeModule(reactContext: ReactApplicationContext) : ReactCon
     @ReactMethod
     fun debug() {
         currentActivity?.let {
-            implementation.debug(it)
+            implementation?.debug(it)
         }
     }
 
@@ -192,7 +192,7 @@ class AppcuesReactNativeModule(reactContext: ReactApplicationContext) : ReactCon
         if (activity != null) {
             val intent = Intent(Intent.ACTION_VIEW)
             intent.data = uri
-            promise.resolve(implementation.onNewIntent(activity, intent))
+            promise.resolve(implementation?.onNewIntent(activity, intent) ?: false)
         } else {
             promise.reject("no-activity", "unable to handle the URL, no current running Activity found")
         }

--- a/ios/AppcuesReactNative.swift
+++ b/ios/AppcuesReactNative.swift
@@ -20,6 +20,7 @@ class AppcuesReactNative: RCTEventEmitter {
                _ reject: @escaping RCTPromiseRejectBlock) {
 
         // since a native module makes native calls asynchronously, we use a Promise here to allow callers to
+        // be able to reliably know when initialization is complete and subsequent SDK calls can continue.
         defer { resolve(nil) }
 
         // Fast refreshing can result in this being called multiple times which gets weird. `guard` is a quick way to shortcut that.


### PR DESCRIPTION
This takes the simplest approach of just using an optional SDK reference, and omitting any calls that may occur before that instance is actually initialized. This type of race condition / crash has been encountered by a couple of customers now, and noted in #63 . Support for waiting on asynchronous init, and related docs were added in #64 . Still, due to how `lateinit` works on Android, a crash could occur if initialization was not waited on.

It's certainly possible to do more here, and I'm open to ideas. For example, we could check for the instance being non-null at every usage call site, then log some sort of warning. I'm not sure if this adds a ton of value versus just extra overhead on every call though. We have the proper usage defined in the docs, and often times any race condition would show up sporadically out in the wild in a spot where Logcat messages aren't really going to help anyway (not in the developer environment).

The simple approach here ends up being exactly the same as iOS, where an optional instance is used and non-initialized calls just get ignored. See https://github.com/appcues/appcues-react-native-module/blob/main/ios/AppcuesReactNative.swift#L58