### PR TITLE
Add support for testID view targeting

### DIFF
--- a/example/components/Button.js
+++ b/example/components/Button.js
@@ -7,6 +7,7 @@ function Button(props) {
       onPress={props.onPress}
       style={props.style.container}
       nativeID={props.nativeID}
+      testID={props.testID}
     >
       <Text style={props.style.buttonText}>{props.title}</Text>
     </TouchableOpacity>

--- a/example/components/TextInput.js
+++ b/example/components/TextInput.js
@@ -19,6 +19,7 @@ export default function TextInput(props) {
         fontSize: 14,
       }}
       nativeID={props.nativeID}
+      testID={props.testID}
     />
   );
 }

--- a/example/screens/main/MainScreen.js
+++ b/example/screens/main/MainScreen.js
@@ -29,17 +29,17 @@ export default function MainScreen() {
       <Tab.Screen
         name="Events"
         component={EventsScreen}
-        options={{ title: 'Events' }}
+        options={{ title: 'Events', tabBarTestID: 'tabEvents' }}
       />
       <Tab.Screen
         name="Profile"
         component={ProfileScreen}
-        options={{ title: 'Profile' }}
+        options={{ title: 'Profile', tabBarTestID: 'tabProfile' }}
       />
       <Tab.Screen
         name="Group"
         component={GroupScreen}
-        options={{ title: 'Group' }}
+        options={{ title: 'Group', tabBarTestID: 'tabGroup' }}
       />
     </Tab.Navigator>
   );


### PR DESCRIPTION
This is a react native element targeting enhancement to try to ensure that we can support targeting tooltips to main navigation tab items, as well as any other view that uses the [testID](https://reactnative.dev/docs/view#testid) property, in addition to [nativeID](https://reactnative.dev/docs/view#nativeid) which we already supported.

Tab bar items did not support `nativeID`, but instead have an option for [tabBarTestID](https://reactnavigation.org/docs/bottom-tab-navigator/#tabbartestid). This change will support either selector type, giving weighted preference to the existing `nativeID`, if both exist. It will also use `testID` for the `displayName`, if no `nativeID` exists.

On iOS, the `testID` value is set in the UIView `accessibilityIdentifier`. On Android, the `testID` value is set on the View `tag` string. In both cases, we can capture this and set in a common `testID` selector property for our usages in element targeting / tooltips.

| iOS | Android |
| --- | --- |
| ![Screenshot 2023-06-16 at 1 12 17 PM](https://github.com/appcues/appcues-react-native-module/assets/19266448/f0991558-b10b-465e-9683-5e432274269c) | ![Screenshot 2023-06-16 at 1 35 53 PM](https://github.com/appcues/appcues-react-native-module/assets/19266448/72e2f37f-d4ac-475d-bc0b-5996eab23536) |

