### PR TITLE
Update native SDK dependencies

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -131,5 +131,5 @@ dependencies {
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.1"
 
     // Appcues
-    implementation "com.appcues:appcues:2.1.1"
+    implementation "com.appcues:appcues:2.1.2"
 }

--- a/appcues-react-native.podspec
+++ b/appcues-react-native.podspec
@@ -16,5 +16,5 @@ Pod::Spec.new do |s|
   s.source_files = "ios/**/*.{h,m,mm,swift}"
 
   s.dependency "React-Core"
-  s.dependency "Appcues", "~> 2.1"
+  s.dependency "Appcues", "~> 2.1.1"
 end

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - Appcues (2.1.0)
+  - Appcues (2.1.1)
   - appcues-react-native (2.0.1):
     - Appcues (~> 2.1)
     - React-Core
@@ -521,7 +521,7 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/ReactCommon/yoga"
 
 SPEC CHECKSUMS:
-  Appcues: fde9454168c732799afd6b7afd62512159b5bf43
+  Appcues: 6293ef6ca66be2e37f9b02248d87de5cbd569a98
   appcues-react-native: 28200d356042b15eff4d67142c96a3ad0a10cafd
   boost: a7c83b31436843459a1961bfd74b96033dc77234
   CocoaAsyncSocket: 065fd1e645c7abab64f7a6a2007a48038fdc6a99

--- a/example/yarn.lock
+++ b/example/yarn.lock
@@ -11,7 +11,7 @@
     "@jridgewell/trace-mapping" "^0.3.9"
 
 "@appcues/react-native@file:..":
-  version "2.0.0"
+  version "2.1.0"
 
 "@babel/code-frame@^7.0.0", "@babel/code-frame@^7.16.7":
   version "7.16.7"


### PR DESCRIPTION
Podspec updated to 2.1.1 to ensure that new builds pick up the patch - resolve issue seen with Expo build system trying to include DocC snippet files.