### PR TITLE
Use the root view bounds when determining if subviews are on screen

### DIFF
--- a/example/android/app/src/main/res/xml/network_security_config.xml
+++ b/example/android/app/src/main/res/xml/network_security_config.xml
@@ -1,12 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
-<network-security-config>
-  <debug-overrides>
+<network-security-config xmlns:tools="http://schemas.android.com/tools">
+  <base-config>
     <trust-anchors>
-      <!-- Trust user added CAs while debuggable only -->
-      <certificates src="user" />
+      <!-- system default -->
+      <certificates src="system" />
+      <!-- Trust user added CAs for debugging
+           NOTE: normally this would be in debug-overrides section ONLY!
+                 but for this sample app, we allow for proxy testing. -->
+      <certificates src="user"
+          tools:ignore="AcceptsUserCertificates" />
     </trust-anchors>
-  </debug-overrides>
-  <domain-config cleartextTrafficPermitted="true">
-    <domain includeSubdomains="true">localhost</domain>
-  </domain-config>
+  </base-config>
 </network-security-config>


### PR DESCRIPTION
The first commit here is unrelated but just a convenience to make it so we can use Charles proxy on release builds of this React Native Android example app like we do the others.

This change removes the usage of DisplayMetrics width/height for determining the container bounds when deciding if views are on screen or not. For some reason, these values can differ from the actual container view width/height on actual devices (did not see this on emulator). Instead, use the root view width/height for the screen being captured - which matches the view metadata that we capture as well in https://github.com/appcues/appcues-android-sdk/blob/main/appcues/src/main/java/com/appcues/debugger/screencapture/Capture.kt#L61-L62

With this change, the targeting of bottom tab elements is working as expected in React Native on both platforms using the  `testID` selectors.

![Screenshot 2023-07-06 at 9 33 30 AM](https://github.com/appcues/appcues-react-native-module/assets/19266448/6ac67f0e-f873-4c46-831b-67e51e59a0b8)
