### PR TITLE
Remove CircleCI cache of example app node_modules directory

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,9 +82,6 @@ jobs:
       - restore_cache:
           keys:
             - 1-dependencies-{{ checksum "package.json" }}
-      - restore_cache:
-          keys:
-            - 7-dependencies-example-{{ checksum "example/package.json" }}
       - run:
           name: Install dependencies
           command: |
@@ -93,9 +90,6 @@ jobs:
       - save_cache:
           key: 1-dependencies-{{ checksum "package.json" }}
           paths: node_modules
-      - save_cache:
-          key: 7-dependencies-example-{{ checksum "example/package.json" }}
-          paths: example/node_modules
       - persist_to_workspace:
           root: .
           paths: .


### PR DESCRIPTION
So I can [stop confusing myself](https://github.com/appcues/appcues-react-native-module/pull/94#discussion_r1260096017).

It looks like this only saves a few seconds in the rather infrequent build, team consensus appears to be that the more reliable output with no cache outweighs the benefit here.