### PR TITLE
Android build updates to support native SDK dependency updates

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -9,7 +9,7 @@ buildscript {
   }
 
   dependencies {
-    classpath 'com.android.tools.build:gradle:7.1.3'
+    classpath 'com.android.tools.build:gradle:7.4.2'
     // noinspection DifferentKotlinGradleVersion
     classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
   }
@@ -27,6 +27,7 @@ def getExtOrIntegerDefault(name) {
 }
 
 android {
+  namespace "com.appcuesreactnative"
   compileSdkVersion getExtOrIntegerDefault('compileSdkVersion')
   defaultConfig {
     minSdkVersion 21

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,3 +1,3 @@
-AppcuesReactNative_kotlinVersion=1.6.21
+AppcuesReactNative_kotlinVersion=1.8.21
 AppcuesReactNative_compileSdkVersion=33
 AppcuesReactNative_targetSdkVersion=33

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -134,6 +134,8 @@ def jscFlavor = 'org.webkit:android-jsc:+'
 def enableHermes = project.ext.react.get("enableHermes", false);
 
 android {
+    namespace "com.appcues.samples.reactnative"
+
     compileSdkVersion rootProject.ext.compileSdkVersion
 
     compileOptions {

--- a/example/android/app/src/main/res/xml/network_security_config.xml
+++ b/example/android/app/src/main/res/xml/network_security_config.xml
@@ -11,4 +11,8 @@
           tools:ignore="AcceptsUserCertificates" />
     </trust-anchors>
   </base-config>
+  <domain-config cleartextTrafficPermitted="true">
+    <domain includeSubdomains="true">localhost</domain>
+    <domain includeSubdomains="true">10.0.1.1</domain>
+  </domain-config>
 </network-security-config>

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -11,7 +11,8 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath('com.android.tools.build:gradle:7.1.3')
+        classpath('com.android.tools.build:gradle:7.4.2')
+        classpath('org.jetbrains.kotlin:kotlin-gradle-plugin:1.8.21')
 
       // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
These are the changes I believe are needed to allow for updating the Android SDK to include the dependency updates in https://github.com/appcues/appcues-android-sdk/pull/434.

Updating the AGP version from 7.1.3 to 7.4.2 allowed for including the updated Android SDK, while not introducing new issues related to an update to AGP 8. Trying to use AGP 8 led to other dependency issues with react native libraries, and may not be advisable yet at this point.

Updated kotlin usage to 1.6.21 -> 1.8.21 as well to match native SDK and move up to current Android Studio version.