### PR TITLE
Do not create element selectors with empty string values

### DIFF
--- a/android/src/main/java/com/appcuesreactnative/ReactNativeElementTargeting.kt
+++ b/android/src/main/java/com/appcuesreactnative/ReactNativeElementTargeting.kt
@@ -147,9 +147,9 @@ private fun View.asCaptureView(screenBounds: Rect): ViewElement? {
 internal fun View.selector(): ReactNativeViewSelector? {
     return ReactNativeViewSelector(
         // captures "nativeID" property set on a react native View
-        nativeId = getTag(R.id.view_tag_native_id)?.toString(),
+        nativeId = getTag(R.id.view_tag_native_id)?.toString()?.ifEmpty { null },
         // captures "testID" property set on a react native View
-        testId = getTag(R.id.react_test_id)?.toString(),
+        testId = getTag(R.id.react_test_id)?.toString()?.ifEmpty { null },
     ).let { if (it.isValid) it else null }
 }
 

--- a/ios/ReactNativeElementTargeting.swift
+++ b/ios/ReactNativeElementTargeting.swift
@@ -86,10 +86,10 @@ internal class ReactNativeElementTargeting: AppcuesElementTargeting {
 extension UIView {
     var reactNativeSelector: ReactNativeElementSelector? {
         return ReactNativeElementSelector(
-            nativeID: nativeID,
+            nativeID: nativeID.flatMap { $0.isEmpty ? nil : $0 },
             // on iOS, the "testID" set on a react native view comes in through
             // the accessibilityIdentifier property on the UIView
-            testID: accessibilityIdentifier
+            testID: accessibilityIdentifier.flatMap { $0.isEmpty ? nil : $0 }
         )
     }
 


### PR DESCRIPTION
There was a customer usage observed where `testID` was present, but had an empty string value. We should not create selectors for this, since they will not give a readable value in the builder, nor will they provide a unique value at runtime that would be usable for targeting content.