### PR TITLE
Add iOS AppcuesFrameView implementation

### DIFF
--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1,7 +1,7 @@
 PODS:
   - Appcues (2.1.1)
-  - appcues-react-native (2.0.1):
-    - Appcues (~> 2.1)
+  - appcues-react-native (2.1.2):
+    - Appcues (~> 2.1.1)
     - React-Core
   - boost (1.76.0)
   - CocoaAsyncSocket (7.6.5)
@@ -356,10 +356,10 @@ PODS:
     - React-jsi (= 0.69.9)
     - React-logger (= 0.69.9)
     - React-perflogger (= 0.69.9)
-  - RNScreens (3.18.2):
+  - RNScreens (3.22.1):
     - React-Core
     - React-RCTImage
-  - RNVectorIcons (9.1.0):
+  - RNVectorIcons (9.2.0):
     - React-Core
   - SocketRocket (0.6.0)
   - Yoga (1.14.0)
@@ -522,10 +522,10 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   Appcues: 6293ef6ca66be2e37f9b02248d87de5cbd569a98
-  appcues-react-native: 28200d356042b15eff4d67142c96a3ad0a10cafd
+  appcues-react-native: b2a16b091467d644bd6b0ff070ce3a6bf765659d
   boost: a7c83b31436843459a1961bfd74b96033dc77234
   CocoaAsyncSocket: 065fd1e645c7abab64f7a6a2007a48038fdc6a99
-  DoubleConversion: 831926d9b8bf8166fd87886c4abab286c2422662
+  DoubleConversion: 5189b271737e1565bdce30deb4a08d647e3f5f54
   FBLazyVector: d3c1d2923b1009f4e709e8f1b793dedf5b323454
   FBReactNativeSpec: d460df7d796ed4979c6cd4e092145b63eb28b5bb
   Flipper: 26fc4b7382499f1281eb8cb921e5c3ad6de91fe0
@@ -538,10 +538,10 @@ SPEC CHECKSUMS:
   Flipper-RSocket: d9d9ade67cbecf6ac10730304bf5607266dd2541
   FlipperKit: cbdee19bdd4e7f05472a66ce290f1b729ba3cb86
   fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9
-  glog: 85ecdd10ee8d8ec362ef519a6a45ff9aa27b2e85
+  glog: 3d02b25ca00c2d456734d0bcff864cbc62f6ae1a
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
   OpenSSL-Universal: ebc357f1e6bc71fa463ccb2fe676756aff50e88c
-  RCT-Folly: 4d8508a426467c48885f1151029bc15fa5d7b3b8
+  RCT-Folly: b9d9fe1fc70114b751c076104e52f3b1b5e5a95a
   RCTRequired: fe80e9f71dd15939e5399dd94d0aa0e5e069d592
   RCTTypeSafety: 4c802f7c4b9e7c55470e7fc56d50385cbfcce89b
   React: efe0b6d0b7401a208d2d1bf8320c0b6a0dcd593b
@@ -568,8 +568,8 @@ SPEC CHECKSUMS:
   React-RCTVibration: ea899478e6f10ee526f476f769ab33211be2addd
   React-runtimeexecutor: df1518d092e8c74cafddc56690d1ac386ec24d7a
   ReactCommon: fac40473e2c4117522384027ab33ad0cb6717dc5
-  RNScreens: 34cc502acf1b916c582c60003dc3089fa01dc66d
-  RNVectorIcons: 7923e585eaeb139b9f4531d25a125a1500162a0b
+  RNScreens: 50ffe2fa2342eabb2d0afbe19f7c1af286bc7fb3
+  RNVectorIcons: fcc2f6cb32f5735b586e66d14103a74ce6ad61f8
   SocketRocket: fccef3f9c5cedea1353a9ef6ada904fde10d6608
   Yoga: 7a4d48cfb35dfa542151e615fa73c1a0d88caf21
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a

--- a/example/screens/main/EmbedScreen.js
+++ b/example/screens/main/EmbedScreen.js
@@ -1,0 +1,93 @@
+import React from 'react';
+import { SafeAreaView, StyleSheet, ScrollView, View } from 'react-native';
+import { useFocusEffect } from '@react-navigation/native';
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import * as Appcues from '@appcues/react-native';
+import { AppcuesFrameView } from '@appcues/react-native';
+import Text from '../../components/Text';
+
+const Stack = createNativeStackNavigator();
+
+const EmbedView = () => {
+  useFocusEffect(
+    React.useCallback(() => {
+      Appcues.screen('Embed Container');
+    }, [])
+  );
+
+  return (
+    <SafeAreaView>
+      <ScrollView>
+        <AppcuesFrameView frameID="frame1" />
+        <View style={styles.textContainer}>
+          <Text style={styles.text}>
+            Embedded Experiences, or Embeds for short, are experiences that are
+            injected inline with the customer application views, rather than
+            overlaid on top. Embeds can contain a variety of content. Any type
+            of experience content you could show in a modal step could also be
+            embedded into a non-modal view in the application. This pattern is
+            commonly used for less obtrusive promotions or supplemental content,
+            inline banners or help tips.
+          </Text>
+        </View>
+        <AppcuesFrameView frameID="frame2" />
+        <View style={styles.textContainer}>
+          <Text>
+            Embeds are a low-code pattern, requiring customer application
+            development work to be done to create and expose injectable view
+            where Appcues content can reside. This involves creating and
+            registering a special AppcuesFrame view types with the iOS and
+            including those views in the customer app layouts. This concept of
+            view embedding is analogous to products like the Google Ads SDKs for
+            mobile display ads. The details of how the embed registered with the
+            native SDKs are outside of the scope of this document, which focuses
+            on the data model updates. SDK documentation will cover those other
+            integration topics.
+          </Text>
+        </View>
+        <AppcuesFrameView frameID="frame3" />
+        <View style={styles.textContainer}>
+          <Text>
+            Before mobile embeds were supported, the Appcues mobile SDKs could
+            render a single mobile flow at a time, modally as an overlay. These
+            experiences could have had modal or tooltip steps, but the response
+            from the server qualification would return a prioritized list of
+            mobile flows and the SDK would render the highest priority item
+            possible. With embeds, this paradigm changes, and a qualification
+            response may contain zero or more mobile embeds that can be rendered
+            simultaneously, as well as zero or more mobile flows, which are
+            handled just like before, rendering a single highest priority item.
+            Mobile embeds and mobile flow pattern types are entirely mutually
+            exclusive, meaning you cannot have tooltip mobile flow steps within
+            an embed experience, for example. However, you can launch a mobile
+            flow from a mobile embed with a button action.
+          </Text>
+        </View>
+      </ScrollView>
+    </SafeAreaView>
+  );
+};
+
+export default function EmbedScreen() {
+  return (
+    <Stack.Navigator>
+      <Stack.Screen
+        name="Embed Experiences"
+        component={EmbedView}
+        options={{
+          headerShadowVisible: false,
+          headerTitleStyle: { fontWeight: '600' },
+        }}
+      />
+    </Stack.Navigator>
+  );
+}
+
+const styles = StyleSheet.create({
+  textContainer: {
+    flex: 1,
+    marginHorizontal: 20,
+    marginBottom: 12,
+    flexDirection: 'row',
+  },
+});

--- a/example/screens/main/EventsScreen.js
+++ b/example/screens/main/EventsScreen.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { View } from 'react-native';
+import { StyleSheet, View } from 'react-native';
 import { useFocusEffect } from '@react-navigation/native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import * as Appcues from '@appcues/react-native';
@@ -15,15 +15,7 @@ const EventsView = () => {
   );
 
   return (
-    <View
-      style={{
-        flex: 1,
-        alignItems: 'stretch',
-        paddingTop: 35,
-        paddingLeft: 25,
-        paddingRight: 25,
-      }}
-    >
+    <View style={styles.container}>
       <TintedButton
         title="Trigger Event 1"
         nativeID="btnEvent1"
@@ -55,3 +47,13 @@ export default function EventsScreen() {
     </Stack.Navigator>
   );
 }
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'stretch',
+    paddingTop: 35,
+    paddingLeft: 40,
+    paddingRight: 40,
+  },
+});

--- a/example/screens/main/GroupScreen.js
+++ b/example/screens/main/GroupScreen.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { View } from 'react-native';
+import { StyleSheet, View } from 'react-native';
 import { useFocusEffect } from '@react-navigation/native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import * as Appcues from '@appcues/react-native';
@@ -19,15 +19,7 @@ const GroupView = () => {
   const [groupID, onChangeGroupID] = React.useState(null);
 
   return (
-    <View
-      style={{
-        flex: 1,
-        alignItems: 'stretch',
-        paddingTop: 35,
-        paddingLeft: 40,
-        paddingRight: 40,
-      }}
-    >
+    <View style={styles.container}>
       <Text>Group</Text>
       <TextInput
         onChangeText={onChangeGroupID}
@@ -61,3 +53,13 @@ export default function GroupScreen() {
     </Stack.Navigator>
   );
 }
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'stretch',
+    paddingTop: 35,
+    paddingLeft: 40,
+    paddingRight: 40,
+  },
+});

--- a/example/screens/main/MainScreen.js
+++ b/example/screens/main/MainScreen.js
@@ -4,6 +4,7 @@ import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
 import EventsScreen from './EventsScreen';
 import ProfileScreen from './ProfileScreen';
 import GroupScreen from './GroupScreen';
+import EmbedScreen from './EmbedScreen';
 
 const Tab = createBottomTabNavigator();
 
@@ -21,6 +22,8 @@ export default function MainScreen() {
             iconName = 'person-outline';
           } else if (route.name === 'Group') {
             iconName = 'people-outline';
+          } else if (route.name === 'Embed') {
+            iconName = 'reader-outline';
           }
           return <Ionicons name={iconName} size={size} color={color} />;
         },
@@ -40,6 +43,11 @@ export default function MainScreen() {
         name="Group"
         component={GroupScreen}
         options={{ title: 'Group', tabBarTestID: 'tabGroup' }}
+      />
+      <Tab.Screen
+        name="Embed"
+        component={EmbedScreen}
+        options={{ title: 'Embed', tabBarTestID: 'tabEmbed' }}
       />
     </Tab.Navigator>
   );

--- a/example/screens/main/ProfileScreen.js
+++ b/example/screens/main/ProfileScreen.js
@@ -1,5 +1,5 @@
 import React, { useContext, useState } from 'react';
-import { View } from 'react-native';
+import { StyleSheet, View } from 'react-native';
 import { useFocusEffect, useNavigation } from '@react-navigation/native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import * as Appcues from '@appcues/react-native';
@@ -22,15 +22,7 @@ const ProfileView = () => {
   const { userID } = useContext(UserContext);
 
   return (
-    <View
-      style={{
-        flex: 1,
-        alignItems: 'stretch',
-        paddingTop: 35,
-        paddingLeft: 40,
-        paddingRight: 40,
-      }}
-    >
+    <View style={styles.container}>
       <Text>Given Name</Text>
       <TextInput
         onChangeText={onChangeGivenName}
@@ -92,3 +84,13 @@ export default function ProfileScreen() {
 function removeEmpty(obj) {
   return Object.fromEntries(Object.entries(obj).filter(([_, v]) => v != null));
 }
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'stretch',
+    paddingTop: 35,
+    paddingLeft: 40,
+    paddingRight: 40,
+  },
+});

--- a/example/screens/signin/SignInScreen.js
+++ b/example/screens/signin/SignInScreen.js
@@ -1,5 +1,5 @@
 import React, { useContext } from 'react';
-import { View } from 'react-native';
+import { StyleSheet, View } from 'react-native';
 import { useFocusEffect, useNavigation } from '@react-navigation/native';
 import * as Appcues from '@appcues/react-native';
 import UserContext from '../../contexts/UserContext';
@@ -18,16 +18,8 @@ export default function SignInScreen() {
   );
 
   return (
-    <View style={{ flex: 1 }}>
-      <View
-        style={{
-          flex: 1,
-          alignItems: 'stretch',
-          paddingTop: 35,
-          paddingLeft: 40,
-          paddingRight: 40,
-        }}
-      >
+    <View style={styles.root}>
+      <View style={styles.container}>
         <Text>User ID</Text>
         <TextInput
           onChangeText={setUserID}
@@ -43,7 +35,7 @@ export default function SignInScreen() {
           }}
         />
       </View>
-      <View style={{ paddingBottom: 35 }}>
+      <View style={styles.anonymousButtonWrapper}>
         <PlainButton
           title="Anonymous User"
           onPress={() => {
@@ -55,3 +47,21 @@ export default function SignInScreen() {
     </View>
   );
 }
+
+const styles = StyleSheet.create({
+  root: {
+    flex: 1,
+  },
+
+  container: {
+    flex: 1,
+    alignItems: 'stretch',
+    paddingTop: 35,
+    paddingLeft: 40,
+    paddingRight: 40,
+  },
+
+  anonymousButtonWrapper: {
+    paddingBottom: 35,
+  },
+});

--- a/ios/AppcuesFrameViewManager.m
+++ b/ios/AppcuesFrameViewManager.m
@@ -1,0 +1,8 @@
+#import <React/RCTViewManager.h>
+
+@interface RCT_EXTERN_MODULE(AppcuesFrameViewManager, RCTViewManager)
+
+RCT_EXPORT_VIEW_PROPERTY(frameID, NSString)
+RCT_EXPORT_VIEW_PROPERTY(fixedSize, BOOL)
+
+@end

--- a/ios/AppcuesFrameViewManager.m
+++ b/ios/AppcuesFrameViewManager.m
@@ -3,6 +3,5 @@
 @interface RCT_EXTERN_MODULE(AppcuesFrameViewManager, RCTViewManager)
 
 RCT_EXPORT_VIEW_PROPERTY(frameID, NSString)
-RCT_EXPORT_VIEW_PROPERTY(fixedSize, BOOL)
 
 @end

--- a/ios/AppcuesFrameViewManager.swift
+++ b/ios/AppcuesFrameViewManager.swift
@@ -1,0 +1,89 @@
+import AppcuesKit
+
+@objc(AppcuesFrameViewManager)
+class AppcuesFrameViewManager: RCTViewManager {
+
+    override func view() -> WrapperView {
+        return WrapperView(uiManager: bridge.uiManager)
+    }
+
+    @objc override static func requiresMainQueueSetup() -> Bool {
+        return false
+    }
+}
+
+class WrapperView: UIView {
+    weak var uiManager: RCTUIManager?
+
+    @objc var frameID: String? = nil
+    @objc var fixedSize: Bool = false {
+        didSet {
+            if let fixedSizeConstraint = fixedSizeConstraint {
+                fixedSizeConstraint.isActive = fixedSize
+            }
+        }
+    }
+
+    private var frameView: AppcuesFrameView?
+    private var fixedSizeConstraint: NSLayoutConstraint?
+
+    init(uiManager: RCTUIManager) {
+        self.uiManager = uiManager
+        super.init(frame: .zero)
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+
+        // One-time setup once all the required info is available
+        if frameView == nil,
+           let frameID = frameID,
+           let appcues = AppcuesReactNative.implementation,
+           let parentViewController = parentViewController {
+            let view = AppcuesFrameView()
+            view.translatesAutoresizingMaskIntoConstraints = false
+
+            addSubview(view)
+            var constraints = [
+                view.topAnchor.constraint(equalTo: topAnchor),
+                view.leadingAnchor.constraint(equalTo: leadingAnchor),
+                view.trailingAnchor.constraint(equalTo: trailingAnchor),
+            ]
+
+            // Create the constraint, but only activate it when needed. The didSet for `fixedSize` will toggle so that the setting is dynamic.
+            let constraint = view.bottomAnchor.constraint(equalTo: bottomAnchor)
+            fixedSizeConstraint = constraint
+
+            if fixedSize {
+                constraints.append(constraint)
+            }
+
+            NSLayoutConstraint.activate(constraints)
+
+            appcues.register(frameID: frameID, for: view, on: parentViewController)
+            frameView = view
+        }
+
+        if !fixedSize, let bounds = frameView?.bounds {
+            uiManager?.setIntrinsicContentSize(bounds.size, for: self)
+        }
+    }
+}
+
+extension UIView {
+    var parentViewController: UIViewController? {
+        var parentResponder: UIResponder? = self
+        while parentResponder != nil {
+            parentResponder = parentResponder!.next
+            if let viewController = parentResponder as? UIViewController {
+                return viewController
+            }
+        }
+        return nil
+    }
+}

--- a/ios/AppcuesReactNative-Bridging-Header.h
+++ b/ios/AppcuesReactNative-Bridging-Header.h
@@ -1,3 +1,4 @@
 #import <React/RCTBridgeModule.h>
 #import <React/RCTEventEmitter.h>
 #import <React/RCTViewManager.h>
+#import <React/RCTUIManager.h>

--- a/ios/AppcuesReactNative.swift
+++ b/ios/AppcuesReactNative.swift
@@ -4,7 +4,7 @@ import AppcuesKit
 class AppcuesReactNative: RCTEventEmitter {
     private static let eventName = "analytics"
 
-    private var implementation: Appcues?
+    static var implementation: Appcues?
 
     private var hasListeners = false
 
@@ -24,7 +24,7 @@ class AppcuesReactNative: RCTEventEmitter {
         defer { resolve(nil) }
 
         // Fast refreshing can result in this being called multiple times which gets weird. `guard` is a quick way to shortcut that.
-        guard implementation == nil else { return }
+        guard AppcuesReactNative.implementation == nil else { return }
 
         let config = Appcues.Config(accountID: accountID, applicationID: applicationID)
 
@@ -50,8 +50,8 @@ class AppcuesReactNative: RCTEventEmitter {
 
         config.additionalAutoProperties(additionalAutoProperties)
 
-        implementation = Appcues(config: config)
-        implementation?.analyticsDelegate = self
+        AppcuesReactNative.implementation = Appcues(config: config)
+        AppcuesReactNative.implementation?.analyticsDelegate = self
 
         if #available(iOS 13.0, *) {
             Appcues.elementTargeting = ReactNativeElementTargeting()
@@ -60,37 +60,37 @@ class AppcuesReactNative: RCTEventEmitter {
 
     @objc
     func identify(_ userID: String, properties: [String: Any]) {
-        implementation?.identify(userID: userID, properties: properties)
+        AppcuesReactNative.implementation?.identify(userID: userID, properties: properties)
     }
 
     @objc
     func reset() {
-        implementation?.reset()
+        AppcuesReactNative.implementation?.reset()
     }
 
     @objc
     func anonymous() {
-        implementation?.anonymous()
+        AppcuesReactNative.implementation?.anonymous()
     }
 
     @objc
     func group(_ groupID: String?, properties: [String: Any]) {
-        implementation?.group(groupID: groupID, properties: properties)
+        AppcuesReactNative.implementation?.group(groupID: groupID, properties: properties)
     }
 
     @objc
     func screen(_ title: String, properties: [String: Any]) {
-        implementation?.screen(title: title, properties: properties)
+        AppcuesReactNative.implementation?.screen(title: title, properties: properties)
     }
 
     @objc
     func track(_ name: String, properties: [String: Any]) {
-        implementation?.track(name: name, properties: properties)
+        AppcuesReactNative.implementation?.track(name: name, properties: properties)
     }
 
     @objc
     func show(_ experienceID: String, resolver resolve: @escaping RCTPromiseResolveBlock, rejecter reject: @escaping RCTPromiseRejectBlock) {
-        implementation?.show(experienceID: experienceID) { success, error in
+        AppcuesReactNative.implementation?.show(experienceID: experienceID) { success, error in
             if success {
                 resolve(nil)
             } else {
@@ -102,14 +102,14 @@ class AppcuesReactNative: RCTEventEmitter {
     @objc
     func debug() {
         DispatchQueue.main.async {
-            self.implementation?.debug()
+            AppcuesReactNative.implementation?.debug()
         }
     }
 
     @objc
     func didHandleURL(_ url: String, resolver resolve: @escaping RCTPromiseResolveBlock, rejecter reject: RCTPromiseRejectBlock) {
         guard let url = URL(string: url) else { return resolve(false) }
-        guard let implementation = implementation else { return resolve(false) }
+        guard let implementation = AppcuesReactNative.implementation else { return resolve(false) }
 
         DispatchQueue.main.async {
             resolve(implementation.didHandleURL(url))

--- a/ios/AppcuesReactNative.xcodeproj/project.pbxproj
+++ b/ios/AppcuesReactNative.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		C96421D52A72B9C0000A6FD2 /* AppcuesFrameViewManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C96421D32A7199B8000A6FD2 /* AppcuesFrameViewManager.swift */; };
 		F4FF95D7245B92E800C19C63 /* AppcuesReactNative.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4FF95D6245B92E800C19C63 /* AppcuesReactNative.swift */; };
 /* End PBXBuildFile section */
 
@@ -26,6 +27,8 @@
 		134814201AA4EA6300B7C361 /* libAppcuesReactNative.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libAppcuesReactNative.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		1A790AB829C9E893009BDF5D /* ReactNativeElementTargeting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReactNativeElementTargeting.swift; sourceTree = "<group>"; };
 		B3E7B5891CC2AC0600A0062D /* AppcuesReactNative.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AppcuesReactNative.m; sourceTree = "<group>"; };
+		C96421D22A7199B8000A6FD2 /* AppcuesFrameViewManager.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AppcuesFrameViewManager.m; sourceTree = "<group>"; };
+		C96421D32A7199B8000A6FD2 /* AppcuesFrameViewManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppcuesFrameViewManager.swift; sourceTree = "<group>"; };
 		F4FF95D5245B92E700C19C63 /* AppcuesReactNative-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "AppcuesReactNative-Bridging-Header.h"; sourceTree = "<group>"; };
 		F4FF95D6245B92E800C19C63 /* AppcuesReactNative.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppcuesReactNative.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -55,6 +58,8 @@
 				1A790AB829C9E893009BDF5D /* ReactNativeElementTargeting.swift */,
 				F4FF95D6245B92E800C19C63 /* AppcuesReactNative.swift */,
 				B3E7B5891CC2AC0600A0062D /* AppcuesReactNative.m */,
+				C96421D22A7199B8000A6FD2 /* AppcuesFrameViewManager.m */,
+				C96421D32A7199B8000A6FD2 /* AppcuesFrameViewManager.swift */,
 				F4FF95D5245B92E700C19C63 /* AppcuesReactNative-Bridging-Header.h */,
 				134814211AA4EA7D00B7C361 /* Products */,
 			);
@@ -117,6 +122,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				C96421D52A72B9C0000A6FD2 /* AppcuesFrameViewManager.swift in Sources */,
 				F4FF95D7245B92E800C19C63 /* AppcuesReactNative.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "release": "./scripts/release.sh",
     "example": "yarn --cwd example",
     "pods": "cd example && pod-install --quiet",
-    "bootstrap": "yarn example && yarn && yarn pods"
+    "bootstrap": "yarn example && yarn && yarn pods",
+    "sync": "./scripts/sync.sh"
   },
   "keywords": [
     "react-native",

--- a/scripts/sync.sh
+++ b/scripts/sync.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+# compile typescript to ./lib
+yarn prepare
+
+# copy relevant files to example app
+cp -R ./android ./example/node_modules/@appcues/react-native
+cp -R ./ios ./example/node_modules/@appcues/react-native
+cp -R ./lib ./example/node_modules/@appcues/react-native
+# ./src isn't strictly necessary, but copying anyways to avoid confusion
+cp -R ./src ./example/node_modules/@appcues/react-native

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -83,7 +83,6 @@ const ComponentName = 'AppcuesFrameView';
 
 type AppcuesFrameProps = {
   frameID: string;
-  fixedSize: boolean;
   style: ViewStyle;
 };
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,4 +1,10 @@
-import { NativeModules, Platform } from 'react-native';
+import {
+  requireNativeComponent,
+  NativeModules,
+  Platform,
+  UIManager,
+  type ViewStyle,
+} from 'react-native';
 
 interface ReactNativeOptions {
   logging?: boolean;
@@ -72,3 +78,18 @@ export function debug() {
 export function didHandleURL(url: string): Promise<boolean> {
   return AppcuesReactNative.didHandleURL(url);
 }
+
+const ComponentName = 'AppcuesFrameView';
+
+type AppcuesFrameProps = {
+  frameID: string;
+  fixedSize: boolean;
+  style: ViewStyle;
+};
+
+export const AppcuesFrameView =
+  UIManager.getViewManagerConfig(ComponentName) != null
+    ? requireNativeComponent<AppcuesFrameProps>(ComponentName)
+    : () => {
+        throw new Error(LINKING_ERROR);
+      };


### PR DESCRIPTION
To make this work, the example app Podfile needs to be updated to use the local iOS SDK (until we release 3.0.0), so:
```rb
pod 'Appcues', :path => '../../../appcues-ios-sdk/Appcues.podspec'
```

## How it works

The Appcues instance is now static so that the `AppcuesFrameViewManager` can access it. The general pattern is very similar to the SwiftUI implementation, just with a `WrapperView` that's roughly equivalent to the `AppcuesFrame: UIViewControllerRepresentable`.

## `yarn sync`

The new `yarn sync` command will copy all the files from the main module into the `node_modules` in the example app. This is substantially quicker than running some version of `yarn install` in the example app.

Note that `yarn example start` already does something similar, but without actually updating the `node_modules` files. This is an alias for `react-native start` and I don't know exactly how it works, so `yarn sync` seems safer.

## Misc

I also cleaned up some of the styles in the example app to use StyleSheet because I was tired of lint warnings complaining about inline styles.