### PR TITLE
Add Android AppcuesFrameView implementation

### DIFF
--- a/android/src/main/java/com/appcuesreactnative/AppcuesFrameViewManager.kt
+++ b/android/src/main/java/com/appcuesreactnative/AppcuesFrameViewManager.kt
@@ -1,0 +1,78 @@
+package com.appcuesreactnative
+
+import android.content.Context
+import android.view.View
+import android.widget.FrameLayout
+import androidx.core.view.children
+import com.appcues.AppcuesFrameView
+import com.facebook.react.uimanager.ThemedReactContext
+import com.facebook.react.uimanager.UIManagerModule
+import com.facebook.react.uimanager.ViewGroupManager
+import com.facebook.react.uimanager.annotations.ReactProp
+
+
+internal class AppcuesFrameViewManager: ViewGroupManager<AppcuesWrapperView>() {
+
+    override fun getName() = REACT_CLASS
+
+    companion object {
+        const val REACT_CLASS = "AppcuesFrameView"
+    }
+
+    override fun createViewInstance(context: ThemedReactContext): AppcuesWrapperView {
+        val wrapperView = AppcuesWrapperView(context)
+        val frameView = AppcuesFrameView(context)
+        wrapperView.contentView = frameView
+        return wrapperView
+    }
+
+    @ReactProp(name = "frameID")
+    fun setFrameId(view: AppcuesWrapperView, frameId: String) {
+        (view.contentView as? AppcuesFrameView)?.let {
+            AppcuesReactNativeModule.implementation?.registerEmbed(frameId, it)
+        }
+    }
+}
+
+internal class AppcuesWrapperView(context: Context) : FrameLayout(context) {
+    var contentView: View? = null
+        set(view) {
+            field = view
+            addView(contentView)
+        }
+
+    override fun requestLayout() {
+        super.requestLayout()
+        post(measureAndLayout)
+    }
+
+    private val measureAndLayout = Runnable {
+        measure(
+            MeasureSpec.makeMeasureSpec(width, MeasureSpec.EXACTLY),
+            MeasureSpec.makeMeasureSpec(height, MeasureSpec.EXACTLY)
+        )
+        layout(left, top, right, bottom)
+    }
+
+    override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {
+        var maxWidth = 0
+        var maxHeight = 0
+        children.forEach {
+            if (it.visibility != GONE) {
+                it.measure(widthMeasureSpec, MeasureSpec.UNSPECIFIED)
+                maxWidth = maxWidth.coerceAtLeast(it.measuredWidth)
+                maxHeight = maxHeight.coerceAtLeast(it.measuredHeight)
+            }
+        }
+        val finalWidth = maxWidth.coerceAtLeast(suggestedMinimumWidth)
+        val finalHeight = maxHeight.coerceAtLeast(suggestedMinimumHeight)
+        setMeasuredDimension(finalWidth, finalHeight)
+        (context as? ThemedReactContext)?.let { themedReactContext ->
+            themedReactContext.runOnNativeModulesQueueThread {
+                themedReactContext.getNativeModule(UIManagerModule::class.java)
+                    ?.updateNodeSize(id, finalWidth, finalHeight)
+            }
+        }
+
+    }
+}

--- a/android/src/main/java/com/appcuesreactnative/AppcuesFrameViewManager.kt
+++ b/android/src/main/java/com/appcuesreactnative/AppcuesFrameViewManager.kt
@@ -1,7 +1,6 @@
 package com.appcuesreactnative
 
 import android.content.Context
-import android.view.View
 import android.widget.FrameLayout
 import androidx.core.view.children
 import com.appcues.AppcuesFrameView
@@ -20,26 +19,21 @@ internal class AppcuesFrameViewManager: ViewGroupManager<AppcuesWrapperView>() {
     }
 
     override fun createViewInstance(context: ThemedReactContext): AppcuesWrapperView {
-        val wrapperView = AppcuesWrapperView(context)
-        val frameView = AppcuesFrameView(context)
-        wrapperView.contentView = frameView
-        return wrapperView
+        return AppcuesWrapperView(context)
     }
 
     @ReactProp(name = "frameID")
     fun setFrameId(view: AppcuesWrapperView, frameId: String) {
-        (view.contentView as? AppcuesFrameView)?.let {
-            AppcuesReactNativeModule.implementation?.registerEmbed(frameId, it)
-        }
+        AppcuesReactNativeModule.implementation?.registerEmbed(frameId, view.contentView)
     }
 }
 
 internal class AppcuesWrapperView(context: Context) : FrameLayout(context) {
-    var contentView: View? = null
-        set(view) {
-            field = view
-            addView(contentView)
-        }
+    val contentView: AppcuesFrameView = AppcuesFrameView(context)
+
+    init {
+        addView(contentView)
+    }
 
     override fun requestLayout() {
         super.requestLayout()

--- a/android/src/main/java/com/appcuesreactnative/AppcuesReactNativeModule.kt
+++ b/android/src/main/java/com/appcuesreactnative/AppcuesReactNativeModule.kt
@@ -7,15 +7,26 @@ import com.appcues.AnalyticType
 import com.appcues.AnalyticsListener
 import com.appcues.Appcues
 import com.appcues.LoggingLevel
-import com.facebook.react.bridge.*
+import com.facebook.react.bridge.Arguments
+import com.facebook.react.bridge.Promise
+import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.bridge.ReactContextBaseJavaModule
+import com.facebook.react.bridge.ReactMethod
+import com.facebook.react.bridge.ReadableArray
+import com.facebook.react.bridge.ReadableMap
+import com.facebook.react.bridge.WritableArray
+import com.facebook.react.bridge.WritableMap
 import com.facebook.react.modules.core.DeviceEventManagerModule
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 
-class AppcuesReactNativeModule(reactContext: ReactApplicationContext) : ReactContextBaseJavaModule(reactContext) {
+internal class AppcuesReactNativeModule(reactContext: ReactApplicationContext)
+    : ReactContextBaseJavaModule(reactContext) {
 
-    private var implementation: Appcues? = null
+    companion object {
+        var implementation: Appcues? = null
+    }
 
     private val mainScope = CoroutineScope(Dispatchers.Main)
 
@@ -28,11 +39,11 @@ class AppcuesReactNativeModule(reactContext: ReactApplicationContext) : ReactCon
 
     @ReactMethod
     fun setup(
-      accountID: String,
-      applicationID: String,
-      options: ReadableMap?,
-      additionalAutoProperties: ReadableMap?,
-      promise: Promise
+        accountID: String,
+        applicationID: String,
+        options: ReadableMap?,
+        additionalAutoProperties: ReadableMap?,
+        promise: Promise
     ) {
         val context = reactApplicationContextIfActiveOrWarn
         if (context == null) {

--- a/android/src/main/java/com/appcuesreactnative/AppcuesReactNativePackage.kt
+++ b/android/src/main/java/com/appcuesreactnative/AppcuesReactNativePackage.kt
@@ -6,12 +6,12 @@ import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.uimanager.ViewManager
 
 
-class AppcuesReactNativePackage : ReactPackage {
+internal class AppcuesReactNativePackage : ReactPackage {
     override fun createNativeModules(reactContext: ReactApplicationContext): List<NativeModule> {
         return listOf(AppcuesReactNativeModule(reactContext))
     }
 
     override fun createViewManagers(reactContext: ReactApplicationContext): List<ViewManager<*, *>> {
-        return emptyList()
+        return listOf(AppcuesFrameViewManager())
     }
 }


### PR DESCRIPTION
Stacks on #101 and adds the Android side of embeds. A similar type of implementation with a View Manager providing a way to instantiate and wrap the native view. The key aspect for auto sizing is the `onMeasure` override, where the content size is passed through the `UIManager` module.

(relies on unreleased 3.0.0 embed functionality in the core SDK - testing locally with a local maven package)