### PR TITLE
Add support for additionalAutoProperties during plugin initialization

### DIFF
--- a/android/src/main/java/com/appcuesreactnative/AppcuesReactNativeModule.kt
+++ b/android/src/main/java/com/appcuesreactnative/AppcuesReactNativeModule.kt
@@ -45,6 +45,8 @@ class AppcuesReactNativeModule(reactContext: ReactApplicationContext) : ReactCon
             return
         }
         implementation = Appcues(context, accountID, applicationID) {
+            val autoProps = hashMapOf<String, Any>()
+
             options?.toHashMap()?.let {
 
                 val logging = it["logging"] as? Boolean
@@ -71,9 +73,17 @@ class AppcuesReactNativeModule(reactContext: ReactApplicationContext) : ReactCon
                 if (activityStorageMaxAge != null) {
                     this.activityStorageMaxAge = activityStorageMaxAge.toInt()
                 }
+
+                val autoPropsFromOptions = it["additionalAutoProperties"] as? HashMap<String, Any>
+                if (autoPropsFromOptions != null) {
+                    autoProps.putAll(autoPropsFromOptions)
+                }
             }
 
-            this.additionalAutoProperties = additionalAutoProperties?.toHashMap() ?: emptyMap()
+            // take any auto properties provided from the calling application, and merge with our internal
+            // auto properties passed in an additional argument.
+            autoProps.putAll(additionalAutoProperties?.toHashMap() ?: emptyMap())
+            this.additionalAutoProperties = autoProps
 
             this.analyticsListener = object: AnalyticsListener {
                 override fun trackedAnalytic(

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1,7 +1,7 @@
 PODS:
   - Appcues (2.1.1)
-  - appcues-react-native (2.0.1):
-    - Appcues (~> 2.1)
+  - appcues-react-native (2.1.3):
+    - Appcues (~> 2.1.1)
     - React-Core
   - boost (1.76.0)
   - CocoaAsyncSocket (7.6.5)
@@ -522,7 +522,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   Appcues: 6293ef6ca66be2e37f9b02248d87de5cbd569a98
-  appcues-react-native: 28200d356042b15eff4d67142c96a3ad0a10cafd
+  appcues-react-native: 760435414a10549e5bf6a70052e4f5e221ace05d
   boost: a7c83b31436843459a1961bfd74b96033dc77234
   CocoaAsyncSocket: 065fd1e645c7abab64f7a6a2007a48038fdc6a99
   DoubleConversion: 831926d9b8bf8166fd87886c4abab286c2422662

--- a/ios/AppcuesReactNative.swift
+++ b/ios/AppcuesReactNative.swift
@@ -48,7 +48,11 @@ class AppcuesReactNative: RCTEventEmitter {
             config.activityStorageMaxAge(activityStorageMaxAge)
         }
 
-        config.additionalAutoProperties(additionalAutoProperties)
+        // take any auto properties provided from the calling application, and merge with our internal
+        // auto properties passed in an additional argument.
+        let autoPropsFromOptions = options["additionalAutoProperties"] as? [String: Any] ?? [:]
+        let mergedAutoProperties = autoPropsFromOptions.merging(additionalAutoProperties) { _, new in new }
+        config.additionalAutoProperties(mergedAutoProperties)
 
         implementation = Appcues(config: config)
         implementation?.analyticsDelegate = self

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -6,6 +6,7 @@ interface ReactNativeOptions {
   sessionTimeout?: number;
   activityStorageMaxSize?: number;
   activityStorageMaxAge?: number;
+  additionalAutoProperties?: any;
 }
 
 const LINKING_ERROR =


### PR DESCRIPTION
This allows us to pass through more additional props from the caller of the plugin, similar to how the native SDKs work. On the JS side it would look like:

```js
await Appcues.setup('APPCUES_ACCOUNT_ID', 'APPCUES_APPLICATION_ID', {
  additionalAutoProperties: { 
    autoProp1: "value", 
    autoProp2: 12 
  }
});
```

These get merged with the built in auto props that identify the framework and version.

I'd like to have this option so that the new Segment plugin (in the works) can pass through the Segment SDK information and we can have an indicator in the data which usage is coming through the Segment plugin.