### PR TITLE
Update expo install command in docs

### DIFF
--- a/docs/ExpoBareWorkflow.md
+++ b/docs/ExpoBareWorkflow.md
@@ -5,7 +5,7 @@ The Appcues React Native module can be easily integrated into an app using the E
 ## Installation and Setup
 
 ```sh
-$ expo install @appcues/react-native
+$ npx expo install @appcues/react-native
 ```
 
 ```js

--- a/docs/ExpoManagedWorkflow.md
+++ b/docs/ExpoManagedWorkflow.md
@@ -5,7 +5,7 @@ The Appcues React Native module can be integrated into an app using the Expo Man
 ## Installation and Setup
 
 ```sh
-$ expo install @appcues/react-native
+$ npx expo install @appcues/react-native
 ```
 
 ### Wrapping the Appcues SDK
@@ -106,7 +106,7 @@ Instead of importing from `@appcues/react-native` directly, reference the `Appcu
 A development build is necessary to use actually use the real Appcues SDK functionality. The [Getting Started](https://docs.expo.dev/development/getting-started) guide provided by Expo is a comprehensive reference, but the minimal steps are described here:
 
 ```sh
- $ expo install expo-dev-client
+ $ npx expo install expo-dev-client
 
  # ios
  $ eas device:create # register test devices onto ad hoc provisioning profile
@@ -116,7 +116,7 @@ A development build is necessary to use actually use the real Appcues SDK functi
  eas build --profile development --platform android
 
  # Install the build on a device, then:
- $ expo start --dev-client
+ $ npx expo start --dev-client
 
  # Then scan the QR code to open on the device
  ```


### PR DESCRIPTION
Just doing `expo install` gives a warning now:
```
┌───────────────────────────────────────────────────────────────────────────┐
│                                                                           │
│   The global expo-cli package has been deprecated.                        │
│                                                                           │
│   The new Expo CLI is now bundled in your project in the expo package.    │
│   Learn more: https://blog.expo.dev/the-new-expo-cli-f4250d8e3421.        │
│                                                                           │
│   To use the local CLI instead (recommended in SDK 46 and higher), run:   │
│   › npx expo <command>                                                    │
│                                                                           │
└───────────────────────────────────────────────────────────────────────────┘
```