### PR TITLE
Add support for custom font path in init options

### DIFF
--- a/android/src/main/java/com/appcuesreactnative/AppcuesReactNativeModule.kt
+++ b/android/src/main/java/com/appcuesreactnative/AppcuesReactNativeModule.kt
@@ -57,6 +57,7 @@ internal class AppcuesReactNativeModule(reactContext: ReactApplicationContext)
         }
         implementation = Appcues(context, accountID, applicationID) {
             val autoProps = hashMapOf<String, Any>()
+            var fontAssetPath: String? = null
 
             options?.toHashMap()?.let {
 
@@ -85,11 +86,16 @@ internal class AppcuesReactNativeModule(reactContext: ReactApplicationContext)
                     this.activityStorageMaxAge = activityStorageMaxAge.toInt()
                 }
 
+                fontAssetPath = it["androidFontsPath"] as? String
+
                 val autoPropsFromOptions = it["additionalAutoProperties"] as? HashMap<String, Any>
                 if (autoPropsFromOptions != null) {
                     autoProps.putAll(autoPropsFromOptions)
                 }
             }
+
+            // check in the assets root, by default, unless alternative specified
+            this.fontAssetPath = fontAssetPath ?: ""
 
             // take any auto properties provided from the calling application, and merge with our internal
             // auto properties passed in an additional argument.

--- a/docs/ExpoManagedWorkflow.md
+++ b/docs/ExpoManagedWorkflow.md
@@ -101,6 +101,17 @@ Instead of importing from `@appcues/react-native` directly, reference the `Appcu
  > <WrappedAppcuesFrameView frameID="frame-id" />
  > ```
 
+### Custom Fonts
+
+If your application uses custom fonts, optionally supply initialization options declaring where those font files can be found at runtime, for usage in Appcues experiences. These paths are platform specific, and the default values used by Expo are shown below. The iOS path refers to the path where font assets can be found in the app bundle. The Android path refers to the path within the application assets where fonts can be found, by default, the at the root level (empty string). If you are using the default path, you do not need to specify any init option value - these will already be used by default.
+
+```js
+await AppcuesWrapper.setup('APPCUES_ACCOUNT_ID', 'APPCUES_APPLICATION_ID', {
+  iosFontsPath: '/assets/assets/fonts',
+  androidFontsPath: '',
+});
+```
+
 ### Create a Development Build
 
 A development build is necessary to use actually use the real Appcues SDK functionality. The [Getting Started](https://docs.expo.dev/development/getting-started) guide provided by Expo is a comprehensive reference, but the minimal steps are described here:

--- a/ios/AppcuesReactNative.swift
+++ b/ios/AppcuesReactNative.swift
@@ -48,6 +48,11 @@ class AppcuesReactNative: RCTEventEmitter {
             config.activityStorageMaxAge(activityStorageMaxAge)
         }
 
+        // check in "/assets/assets/fonts" by default, unless alternative specified
+        let bundleFontsPath = (options["iosFontsPath"] as? String) ?? "/assets/assets/fonts"
+        config.bundleFontsPath(bundleFontsPath)
+
+
         // take any auto properties provided from the calling application, and merge with our internal
         // auto properties passed in an additional argument.
         let autoPropsFromOptions = options["additionalAutoProperties"] as? [String: Any] ?? [:]

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -13,6 +13,8 @@ interface ReactNativeOptions {
   activityStorageMaxSize?: number;
   activityStorageMaxAge?: number;
   additionalAutoProperties?: any;
+  iosFontsPath?: string;
+  androidFontsPath?: string;
 }
 
 const LINKING_ERROR =


### PR DESCRIPTION
stacks on #108 

This update allows specifying a platform specific custom font path that gets passed into the native SDK for resolving app specific fonts. This is to support Expo managed workflow custom font usage. Internally, we always check in the default locations, so this only needs to be specified if the path differs in a given app.