### PR TITLE
🐛 Ensure FrameView margins are added to the content size to avoid unnecessary scrolling

### DIFF
--- a/ios/AppcuesFrameViewManager.swift
+++ b/ios/AppcuesFrameViewManager.swift
@@ -86,6 +86,13 @@ class AppcuesFrameVC: UIViewController {
         view = frameView
     }
 
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        // Only want to render the margins specified by the embed style
+        viewRespectsSystemMinimumLayoutMargins = false
+    }
+
     override func viewWillLayoutSubviews() {
         super.viewWillLayoutSubviews()
 
@@ -94,7 +101,15 @@ class AppcuesFrameVC: UIViewController {
 
     override func preferredContentSizeDidChange(forChildContentContainer container: UIContentContainer) {
         super.preferredContentSizeDidChange(forChildContentContainer: container)
-        preferredContentSize = container.preferredContentSize
+
+        // Add frame margins to the calculated size. Need to do this because the margins must be set on the FrameView,
+        // not the UIViewController it contains which manages the preferredContentSize
+        let margins = frameView.directionalLayoutMargins
+
+        preferredContentSize = CGSize(
+            width: container.preferredContentSize.width + margins.leading + margins.trailing,
+            height: container.preferredContentSize.height + margins.top + margins.bottom
+        )
 
         parentView?.setIntrinsicSize(preferredContentSize: preferredContentSize, isHidden: frameView.isHidden)
     }


### PR DESCRIPTION
Sibling to
- https://github.com/appcues/appcues-ios-sdk/pull/476