### PR TITLE
use post when adding fragment for embed frame

### DIFF
--- a/android/src/main/java/com/appcuesreactnative/AppcuesFrameViewManager.kt
+++ b/android/src/main/java/com/appcuesreactnative/AppcuesFrameViewManager.kt
@@ -49,7 +49,10 @@ internal class AppcuesWrapperView(context: Context) : FrameLayout(context) {
 
     override fun onAttachedToWindow() {
         super.onAttachedToWindow()
+        post(addFragment)
+    }
 
+    private val addFragment = Runnable {
         if (!fragmentCreated) {
           try {
             val wrapperFragment = AppcuesWrapperFragment(contentView)


### PR DESCRIPTION
The previous fix (in #133) corrected the crash issue that could occur when committing a fragment transaction, however, it could still lead to a handled exception ([on this line](https://github.com/appcues/appcues-react-native-module/blob/main/android/src/main/java/com/appcuesreactnative/AppcuesFrameViewManager.kt#L65)), and the fragment not actually getting configured correctly. This lead to an observed issue where the embed would not render on first screen load, only when leaving and revisiting the screen.

The exception was
```
java.lang.IllegalStateException: FragmentManager is already executing transactions
```

To correct this, we return back to an approach that is similar to the version before the change in #129, where we post a Runnable to add the fragment. However, now that we are using `commitNow()` instead of `commit()` - we can properly catch and handle the exception noted in that prior PR that it was attempting to fix.

I believe the combination of `post(runnable)` + `commitNow()` should solve both issues, and provide the expected embed behavior in all scenarios, in stable fashion.