### PR TITLE
Add config option for dynamic type text scaling on iOS

### DIFF
--- a/ios/AppcuesReactNative.swift
+++ b/ios/AppcuesReactNative.swift
@@ -48,6 +48,9 @@ class AppcuesReactNative: RCTEventEmitter {
             config.activityStorageMaxAge(activityStorageMaxAge)
         }
 
+        // Enable text scaling by default because the React Native Text component has scaling enabled by default.
+        config.enableTextScaling(options["enableTextScaling"] as? Bool ?? true)
+
         // take any auto properties provided from the calling application, and merge with our internal
         // auto properties passed in an additional argument.
         let autoPropsFromOptions = options["additionalAutoProperties"] as? [String: Any] ?? [:]

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -13,6 +13,7 @@ interface ReactNativeOptions {
   activityStorageMaxSize?: number;
   activityStorageMaxAge?: number;
   additionalAutoProperties?: any;
+  enableTextScaling?: boolean;
 }
 
 const LINKING_ERROR =


### PR DESCRIPTION
This option is enabled by default because the React Native Text component has scaling enabled by default.