### PR TITLE
Add support for iOS manual push notification configuration

### DIFF
--- a/example/android/app/google-services.json
+++ b/example/android/app/google-services.json
@@ -2,7 +2,7 @@
   "project_info": {
     "project_number": "465384230434",
     "project_id": "appcues-react-native",
-    "storage_bucket": "appcues-react-native.appspot.com"
+    "storage_bucket": "appcues-react-native.firebasestorage.app"
   },
   "client": [
     {

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -18,7 +18,7 @@ buildscript {
         classpath("com.facebook.react:react-native-gradle-plugin")
         classpath("org.jetbrains.kotlin:kotlin-gradle-plugin")
 
-        classpath("com.google.gms:google-services:4.3.3")
+        classpath("com.google.gms:google-services:4.4.2")
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }

--- a/example/ios/AppcuesReactNativeExample.xcodeproj/project.pbxproj
+++ b/example/ios/AppcuesReactNativeExample.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		0C80B921A6F3F58F76C31292 /* libPods-AppcuesReactNativeExample.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 5DCACB8F33CDC322A6C60F78 /* libPods-AppcuesReactNativeExample.a */; };
 		13B07FBF1A68108700A75B9A /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 13B07FB51A68108700A75B9A /* Images.xcassets */; };
 		81AB9BB82411601600AC10FF /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 81AB9BB72411601600AC10FF /* LaunchScreen.storyboard */; };
+		C989D7112DBFDEE3008670B0 /* AppDelegate+Push.swift in Sources */ = {isa = PBXBuildFile; fileRef = C989D7102DBFDEE3008670B0 /* AppDelegate+Push.swift */; };
 		C9EBCBE92D5BC2E700D38F9D /* NotificationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9EBCBE82D5BC2E700D38F9D /* NotificationService.swift */; };
 		C9EBCBED2D5BC2E700D38F9D /* NotificationServiceExtension.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = C9EBCBE62D5BC2E700D38F9D /* NotificationServiceExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		C9EBCBF82D5BEC1300D38F9D /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9EBCBF72D5BEC1200D38F9D /* AppDelegate.swift */; };
@@ -53,6 +54,7 @@
 		5DCACB8F33CDC322A6C60F78 /* libPods-AppcuesReactNativeExample.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-AppcuesReactNativeExample.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		81AB9BB72411601600AC10FF /* LaunchScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = LaunchScreen.storyboard; path = AppcuesReactNativeExample/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		A683ABC4D04756079BB49854 /* Pods-NotificationServiceExtension.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NotificationServiceExtension.release.xcconfig"; path = "Target Support Files/Pods-NotificationServiceExtension/Pods-NotificationServiceExtension.release.xcconfig"; sourceTree = "<group>"; };
+		C989D7102DBFDEE3008670B0 /* AppDelegate+Push.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "AppDelegate+Push.swift"; path = "AppcuesReactNativeExample/AppDelegate+Push.swift"; sourceTree = "<group>"; };
 		C9EBCBE62D5BC2E700D38F9D /* NotificationServiceExtension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = NotificationServiceExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		C9EBCBE82D5BC2E700D38F9D /* NotificationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationService.swift; sourceTree = "<group>"; };
 		C9EBCBEA2D5BC2E700D38F9D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -86,6 +88,7 @@
 			children = (
 				C9EBCBF22D5BC34E00D38F9D /* AppcuesReactNativeExample.entitlements */,
 				C9EBCBF72D5BEC1200D38F9D /* AppDelegate.swift */,
+				C989D7102DBFDEE3008670B0 /* AppDelegate+Push.swift */,
 				13B07FB51A68108700A75B9A /* Images.xcassets */,
 				13B07FB61A68108700A75B9A /* Info.plist */,
 				81AB9BB72411601600AC10FF /* LaunchScreen.storyboard */,
@@ -357,6 +360,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				C989D7112DBFDEE3008670B0 /* AppDelegate+Push.swift in Sources */,
 				C9EBCBF82D5BEC1300D38F9D /* AppDelegate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -507,10 +511,7 @@
 					"-DFOLLY_CFG_NO_COROUTINES=1",
 					"-DFOLLY_HAVE_CLOCK_GETTIME=1",
 				);
-				OTHER_LDFLAGS = (
-					"$(inherited)",
-					" ",
-				);
+				OTHER_LDFLAGS = "$(inherited)  ";
 				REACT_NATIVE_PATH = "${PODS_ROOT}/../../node_modules/react-native";
 				SDKROOT = iphoneos;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) DEBUG";
@@ -579,10 +580,7 @@
 					"-DFOLLY_CFG_NO_COROUTINES=1",
 					"-DFOLLY_HAVE_CLOCK_GETTIME=1",
 				);
-				OTHER_LDFLAGS = (
-					"$(inherited)",
-					" ",
-				);
+				OTHER_LDFLAGS = "$(inherited)  ";
 				REACT_NATIVE_PATH = "${PODS_ROOT}/../../node_modules/react-native";
 				SDKROOT = iphoneos;
 				USE_HERMES = true;

--- a/example/ios/AppcuesReactNativeExample/AppDelegate+Push.swift
+++ b/example/ios/AppcuesReactNativeExample/AppDelegate+Push.swift
@@ -1,0 +1,55 @@
+//
+//  AppDelegate+Push.swift
+//  AppcuesReactNativeExample
+//
+//  Created by Matt on 2025-04-28.
+//
+
+// Disabled in favor of automatic configuration
+
+/*
+import Foundation
+import UserNotifications
+import appcues_react_native
+
+extension AppDelegate: UNUserNotificationCenterDelegate {
+    /// Call from `UIApplicationDelegate.application(_:didFinishLaunchingWithOptions:)`
+    func setupPush(application: UIApplication) {
+        // 1: Register to get a device token
+        application.registerForRemoteNotifications()
+
+        UNUserNotificationCenter.current().delegate = self
+    }
+
+    // 2: Pass device token to Appcues
+    override func application(_ application: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
+      appcues_react_native.Implementation.setPushToken(deviceToken)
+    }
+
+    // 3: Pass the user's response to a delivered notification to Appcues
+    func userNotificationCenter(
+        _ center: UNUserNotificationCenter,
+        didReceive response: UNNotificationResponse,
+        withCompletionHandler completionHandler: @escaping () -> Void
+    ) {
+        if appcues_react_native.Implementation.didReceiveNotification(response: response, completionHandler: completionHandler) {
+            return
+        }
+
+        completionHandler()
+    }
+
+    // 4: Configure handling for notifications that arrive while the app is in the foreground
+    func userNotificationCenter(
+        _ center: UNUserNotificationCenter,
+        willPresent notification: UNNotification,
+        withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void
+    ) {
+        if #available(iOS 14.0, *) {
+            completionHandler([.banner, .list])
+        } else {
+            completionHandler(.alert)
+        }
+    }
+}
+*/

--- a/example/ios/AppcuesReactNativeExample/AppDelegate.swift
+++ b/example/ios/AppcuesReactNativeExample/AppDelegate.swift
@@ -3,6 +3,7 @@ import React
 import React_RCTAppDelegate
 import ReactAppDependencyProvider
 import AppcuesKit
+//import appcues_react_native
 
 @main
 class AppDelegate: RCTAppDelegate {
@@ -14,7 +15,11 @@ class AppDelegate: RCTAppDelegate {
     // They will be passed down to the ViewController used by React Native.
     self.initialProps = [:]
 
+    // Automatically configure for push notifications
     Appcues.enableAutomaticPushConfig()
+
+    // Or, manually configure for push notifications
+//    setupPush(application: application)
 
     return super.application(application, didFinishLaunchingWithOptions: launchOptions)
   }

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1,6 +1,6 @@
 PODS:
   - Appcues (4.3.6)
-  - appcues-react-native (4.4.0):
+  - appcues-react-native (4.4.1):
     - Appcues (~> 4.3.6)
     - DoubleConversion
     - glog
@@ -1884,7 +1884,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   Appcues: 758c68c206d5329da909f93e79039c1a6332467e
-  appcues-react-native: cf48a899d82958a83f44ee4f7b99a604f55515f8
+  appcues-react-native: f42a8a7af86675ff886808d7b1493ee3a087bb11
   AppcuesNotificationService: fa70b5f904e22f499281235a2511c85ded97c6d0
   boost: 7e761d76ca2ce687f7cc98e698152abd03a18f90
   DoubleConversion: cb417026b2400c8f53ae97020b2be961b59470cb

--- a/ios/Implementation.swift
+++ b/ios/Implementation.swift
@@ -77,6 +77,8 @@ public class Implementation: NSObject {
         if #available(iOS 13.0, *) {
             Appcues.elementTargeting = ReactNativeElementTargeting()
         }
+
+        handleStoredNativePush()
     }
 
     @objc
@@ -142,6 +144,41 @@ public class Implementation: NSObject {
 
         DispatchQueue.main.async {
             resolve(implementation.didHandleURL(url))
+        }
+    }
+}
+
+extension Implementation {
+    private static var pushToken: Data?
+    private static var notificationResponse: UNNotificationResponse?
+
+    @objc
+    public static func setPushToken(_ deviceToken: Data?) {
+        guard let impl = Implementation.implementation else {
+            Implementation.pushToken = deviceToken
+            return
+        }
+
+        impl.setPushToken(deviceToken)
+    }
+
+    @objc
+    public static func didReceiveNotification(response: UNNotificationResponse, completionHandler: @escaping () -> Void) -> Bool {
+        guard let impl = Implementation.implementation else {
+            Implementation.notificationResponse = response
+            return false
+        }
+
+        return impl.didReceiveNotification(response: response, completionHandler: completionHandler)
+    }
+
+    // To be called at setup
+    private func handleStoredNativePush() {
+        if let pushToken = Implementation.pushToken {
+            Implementation.implementation?.setPushToken(pushToken)
+        }
+        if let notification = Implementation.notificationResponse {
+            _ = Implementation.implementation?.didReceiveNotification(response: notification, completionHandler: {})
         }
     }
 }


### PR DESCRIPTION
For an app that chooses not to use `Appcues.enableAutomaticPushConfig()` we now provide 2 public static methods on `appcues_react_native.Implementation` that can be used to pass push data (token and notification response) into the current `Appcues` instance created by the RN module. If there is no instance (yet, due to something that might be triggered right at app launch) the values are saved and passed into the instance when it's set up.

I've added a commented-out example the same way we have it in the iOS sample project.