### PR TITLE
Fix element targeting for nativeID with New Architecture

### DIFF
--- a/example/ios/AppcuesReactNativeExample/AppDelegate.swift
+++ b/example/ios/AppcuesReactNativeExample/AppDelegate.swift
@@ -35,4 +35,8 @@ class AppDelegate: RCTAppDelegate {
     Bundle.main.url(forResource: "main", withExtension: "jsbundle")
 #endif
   }
+
+  override func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey : Any] = [:]) -> Bool {
+    return RCTLinkingManager.application(app, open: url, options: options)
+  }
 }

--- a/ios/ReactNativeElementTargeting.swift
+++ b/ios/ReactNativeElementTargeting.swift
@@ -84,9 +84,20 @@ internal class ReactNativeElementTargeting: AppcuesElementTargeting {
 }
 
 extension UIView {
+    var compatibleNativeID: String? {
+        #if RCT_NEW_ARCH_ENABLED
+        guard responds(to: Selector(("nativeId"))) else {
+            return nil
+        }
+        return value(forKey: "nativeId") as? String
+        #else
+        return nativeID
+        #endif
+    }
+
     var reactNativeSelector: ReactNativeElementSelector? {
         return ReactNativeElementSelector(
-            nativeID: nativeID.flatMap { $0.isEmpty ? nil : $0 },
+            nativeID: compatibleNativeID.flatMap { $0.isEmpty ? nil : $0 },
             // on iOS, the "testID" set on a react native view comes in through
             // the accessibilityIdentifier property on the UIView
             testID: accessibilityIdentifier.flatMap { $0.isEmpty ? nil : $0 }


### PR DESCRIPTION
It turns out that the `nativeID` UIView property is always nil with the New Architecture. `value(forKey: "nativeId")` is a solution to access the value.

I've tested the most relevant compatibility scenarios:
1. An Old Arch iOS screen capture properly works with a New Arch iOS build
2. A New Arch Android build screen capture properly works with a New Arch iOS 
3. A New Arch iOS screen capture properly works with a New Arch Android build
