### PR TITLE
Support RN 0.81 (SDK version 4.4.5)

### DIFF
--- a/android/CMakeLists.txt
+++ b/android/CMakeLists.txt
@@ -52,12 +52,16 @@ else()
   )
 endif()
 
-target_compile_options(
-  react_codegen_AppcuesReactNativeSpec
-  PRIVATE
-  -DLOG_TAG=\"ReactNative\"
-  -fexceptions
-  -frtti
-  -std=c++20
-  -Wall
-)
+if(ReactAndroid_VERSION_MINOR GREATER_EQUAL 80)
+  target_compile_reactnative_options(react_codegen_AppcuesReactNativeSpec PRIVATE)
+else()
+  target_compile_options(
+    react_codegen_AppcuesReactNativeSpec
+    PRIVATE
+    -DLOG_TAG=\"ReactNative\"
+    -fexceptions
+    -frtti
+    -std=c++20
+    -Wall
+  )
+endif()


### PR DESCRIPTION
RN 0.81 requires an update if you use a custom `CMakeLists.txt`: https://reactnative.dev/blog/2025/08/12/react-native-0.81#rn_serializable_state-and-c-flags

Reference implementation: https://github.com/software-mansion/react-native-screens/pull/3114/commits/b4d283c8fc65e36ec60726fd7513735ccc7e1fe9#diff-9c8e037b4165c72aa7a1ce770ef565495239c036cbde67784c399e08a32241b4

This PR targets a release branch for version 4.4.5. I will also create a PR to `main` for 5.0.0.

Fixes #201.