### PR TITLE
Add support for settings path configuration

### DIFF
--- a/android/src/main/java/com/appcuesreactnative/AppcuesReactNativeModule.kt
+++ b/android/src/main/java/com/appcuesreactnative/AppcuesReactNativeModule.kt
@@ -62,6 +62,11 @@ class AppcuesReactNativeModule internal constructor(private val reactContext: Re
                     this.apiBasePath = apiHost
                 }
 
+                val settingsHost = it["settingsHost"] as? String
+                if (settingsHost != null) {
+                    this.apiSettingsPath = settingsHost
+                }
+
                 val sessionTimeout = it["sessionTimeout"] as? Double
                 if (sessionTimeout != null) {
                     this.sessionTimeout = sessionTimeout.toInt()

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1,6 +1,6 @@
 PODS:
   - Appcues (5.0.0)
-  - appcues-react-native (4.4.5):
+  - appcues-react-native (5.0.1):
     - Appcues (~> 5.0.0)
     - DoubleConversion
     - glog
@@ -1884,7 +1884,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   Appcues: d04033bf9e6a6f9803a2f6e466f0a433010a1a87
-  appcues-react-native: 84a8205dd9640af8547e1c40e531291a90a25c9a
+  appcues-react-native: 4805de0e85de0f8917ffcc37fd0c918a2f7a05ab
   AppcuesNotificationService: 84358bc93e1c12a67592cbcd73d0fa1599d51b57
   boost: 7e761d76ca2ce687f7cc98e698152abd03a18f90
   DoubleConversion: cb417026b2400c8f53ae97020b2be961b59470cb

--- a/ios/AppcuesReactNative.mm
+++ b/ios/AppcuesReactNative.mm
@@ -45,6 +45,7 @@ RCT_EXPORT_MODULE()
         optionsDict[@"logging"] = [NSNumber numberWithBool:options.logging().value()];
     }
     optionsDict[@"apiHost"] = options.apiHost();
+    optionsDict[@"settingsHost"] = options.settingsHost();
     if (options.sessionTimeout().has_value()) {
         optionsDict[@"sessionTimeout"] = @(options.sessionTimeout().value());
     }

--- a/ios/Implementation.swift
+++ b/ios/Implementation.swift
@@ -48,6 +48,10 @@ public class Implementation: NSObject {
             config.apiHost(url)
         }
 
+        if let settingsHost = options["settingsHost"] as? String, let url = URL(string: settingsHost) {
+            config.settingsHost(url)
+        }
+
         if let sessionTimeout = options["sessionTimeout"] as? UInt {
             config.sessionTimeout(sessionTimeout)
         }

--- a/src/NativeAppcuesReactNative.ts
+++ b/src/NativeAppcuesReactNative.ts
@@ -4,6 +4,7 @@ import { TurboModuleRegistry } from 'react-native';
 export interface ReactNativeOptions {
   logging?: boolean;
   apiHost?: string;
+  settingsHost?: string;
   sessionTimeout?: number;
   activityStorageMaxSize?: number;
   activityStorageMaxAge?: number;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -3,6 +3,7 @@ import { NativeEventEmitter, NativeModules } from 'react-native';
 interface ReactNativeOptions {
   logging?: boolean;
   apiHost?: string;
+  settingsHost?: string;
   sessionTimeout?: number;
   activityStorageMaxSize?: number;
   activityStorageMaxAge?: number;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds optional `settingsHost` to SDK configuration and wires it through JS, iOS, and Android.
> 
> - Extends `ReactNativeOptions` in `src/NativeAppcuesReactNative.ts` and `src/index.tsx` with `settingsHost`
> - iOS: Passes `settingsHost` through `AppcuesReactNative.mm` (new arch) and applies via `config.settingsHost(...)` in `Implementation.swift`
> - Android: Reads `settingsHost` in `AppcuesReactNativeModule.kt` and sets `apiSettingsPath`
> - Example app: bumps `appcues-react-native` pod to 5.0.1 in `Podfile.lock`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 79ff3367315c5532186e211bcd728b5024449010. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->