### PR TITLE
Update native SDK dependencies

### DIFF
--- a/appcues-react-native.podspec
+++ b/appcues-react-native.podspec
@@ -27,7 +27,7 @@ Pod::Spec.new do |s|
     s.source_files = "ios/*.{h,m,mm,swift}"
   end
 
-  s.dependency "Appcues", "~> 5.0.0"
+  s.dependency "Appcues", "~> 5.0.1"
 
   # Use install_modules_dependencies helper to install the dependencies if React Native version >=0.71.0.
   # See https://github.com/facebook/react-native/blob/febf6b7f33fdb4904669f99d795eba4c0f95d7bf/scripts/cocoapods/new_architecture.rb#L79.

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -42,5 +42,5 @@ target 'AppcuesReactNativeExample' do
 end
 
 target 'NotificationServiceExtension' do
-    pod 'AppcuesNotificationService', '5.0.0'
+    pod 'AppcuesNotificationService', '5.0.1'
 end

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1,7 +1,7 @@
 PODS:
-  - Appcues (5.0.0)
-  - appcues-react-native (5.0.1):
-    - Appcues (~> 5.0.0)
+  - Appcues (5.0.1)
+  - appcues-react-native (5.0.2):
+    - Appcues (~> 5.0.1)
     - DoubleConversion
     - glog
     - hermes-engine
@@ -22,7 +22,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - AppcuesNotificationService (5.0.0)
+  - AppcuesNotificationService (5.0.1)
   - boost (1.84.0)
   - DoubleConversion (1.1.6)
   - fast_float (6.1.4)
@@ -1660,7 +1660,7 @@ PODS:
 
 DEPENDENCIES:
   - appcues-react-native (from `../..`)
-  - AppcuesNotificationService (= 5.0.0)
+  - AppcuesNotificationService (= 5.0.1)
   - boost (from `../node_modules/react-native/third-party-podspecs/boost.podspec`)
   - DoubleConversion (from `../node_modules/react-native/third-party-podspecs/DoubleConversion.podspec`)
   - fast_float (from `../node_modules/react-native/third-party-podspecs/fast_float.podspec`)
@@ -1883,9 +1883,9 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/ReactCommon/yoga"
 
 SPEC CHECKSUMS:
-  Appcues: d04033bf9e6a6f9803a2f6e466f0a433010a1a87
-  appcues-react-native: 4805de0e85de0f8917ffcc37fd0c918a2f7a05ab
-  AppcuesNotificationService: 84358bc93e1c12a67592cbcd73d0fa1599d51b57
+  Appcues: 2a3ac9ea789760c910d1159e2c9c7397b5448ecc
+  appcues-react-native: 78b2aada88af7b8263f7d241437b5387e224626f
+  AppcuesNotificationService: 678ce0235f2b9117d88fabbda13e6aa1a91a26e1
   boost: 7e761d76ca2ce687f7cc98e698152abd03a18f90
   DoubleConversion: cb417026b2400c8f53ae97020b2be961b59470cb
   fast_float: 06eeec4fe712a76acc9376682e4808b05ce978b6
@@ -1957,6 +1957,6 @@ SPEC CHECKSUMS:
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
   Yoga: 78d74e245ed67bb94275a1316cdc170b9b7fe884
 
-PODFILE CHECKSUM: ed94d4da2d79ed7e39e07a933fb0b351ed3887ab
+PODFILE CHECKSUM: 75355d7ef93fb68507e025ca33f8764564cd206e
 
 COCOAPODS: 1.15.2


### PR DESCRIPTION
iOS 5.0.1

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk dependency bump limited to iOS CocoaPods version pins; main risk is upstream behavior changes in `Appcues`/`AppcuesNotificationService` 5.0.1 affecting runtime or notification extension behavior.
> 
> **Overview**
> Updates iOS native SDK dependencies to `Appcues` `~> 5.0.1` in `appcues-react-native.podspec` and bumps the example app’s `AppcuesNotificationService` pod to `5.0.1`.
> 
> Regenerates `example/ios/Podfile.lock` to reflect the new pod versions/checksums (including the example’s `appcues-react-native` pod resolution).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7b01baa8ef534bee583e4345e286ca02171d26ce. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->