### PR TITLE
Update native SDK dependencies

### DIFF
--- a/appcues-react-native.podspec
+++ b/appcues-react-native.podspec
@@ -27,7 +27,7 @@ Pod::Spec.new do |s|
     s.source_files = "ios/*.{h,m,mm,swift}"
   end
 
-  s.dependency "Appcues", "~> 5.0.1"
+  s.dependency "Appcues", "~> 5.0.2"
 
   # Use install_modules_dependencies helper to install the dependencies if React Native version >=0.71.0.
   # See https://github.com/facebook/react-native/blob/febf6b7f33fdb4904669f99d795eba4c0f95d7bf/scripts/cocoapods/new_architecture.rb#L79.

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -42,5 +42,5 @@ target 'AppcuesReactNativeExample' do
 end
 
 target 'NotificationServiceExtension' do
-    pod 'AppcuesNotificationService', '5.0.1'
+    pod 'AppcuesNotificationService', '5.0.2'
 end

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1,7 +1,7 @@
 PODS:
-  - Appcues (5.0.1)
-  - appcues-react-native (5.0.2):
-    - Appcues (~> 5.0.1)
+  - Appcues (5.0.2)
+  - appcues-react-native (5.0.3):
+    - Appcues (~> 5.0.2)
     - DoubleConversion
     - glog
     - hermes-engine
@@ -22,7 +22,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - AppcuesNotificationService (5.0.1)
+  - AppcuesNotificationService (5.0.2)
   - boost (1.84.0)
   - DoubleConversion (1.1.6)
   - fast_float (6.1.4)
@@ -1660,7 +1660,7 @@ PODS:
 
 DEPENDENCIES:
   - appcues-react-native (from `../..`)
-  - AppcuesNotificationService (= 5.0.1)
+  - AppcuesNotificationService (= 5.0.2)
   - boost (from `../node_modules/react-native/third-party-podspecs/boost.podspec`)
   - DoubleConversion (from `../node_modules/react-native/third-party-podspecs/DoubleConversion.podspec`)
   - fast_float (from `../node_modules/react-native/third-party-podspecs/fast_float.podspec`)
@@ -1883,9 +1883,9 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/ReactCommon/yoga"
 
 SPEC CHECKSUMS:
-  Appcues: 2a3ac9ea789760c910d1159e2c9c7397b5448ecc
-  appcues-react-native: 78b2aada88af7b8263f7d241437b5387e224626f
-  AppcuesNotificationService: 678ce0235f2b9117d88fabbda13e6aa1a91a26e1
+  Appcues: e8498480b79832b6301805b0e51c2c98dee5991b
+  appcues-react-native: b95f4bcc95baaa8a0e248312a4713de45f342c93
+  AppcuesNotificationService: 3ae76b53f3fbc3836652551cb23002eae560e637
   boost: 7e761d76ca2ce687f7cc98e698152abd03a18f90
   DoubleConversion: cb417026b2400c8f53ae97020b2be961b59470cb
   fast_float: 06eeec4fe712a76acc9376682e4808b05ce978b6
@@ -1957,6 +1957,6 @@ SPEC CHECKSUMS:
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
   Yoga: 78d74e245ed67bb94275a1316cdc170b9b7fe884
 
-PODFILE CHECKSUM: 75355d7ef93fb68507e025ca33f8764564cd206e
+PODFILE CHECKSUM: 5cae0b01499071396d10dce19e3ea7390b17f5cb
 
 COCOAPODS: 1.15.2


### PR DESCRIPTION
iOS 5.0.2

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk dependency-only update; main impact is potential behavior changes introduced by the upstream `Appcues`/`AppcuesNotificationService` patch release.
> 
> **Overview**
> Updates the CocoaPods dependencies to use `Appcues` `~> 5.0.2` in `appcues-react-native.podspec`, and updates the example app’s `NotificationServiceExtension` to `AppcuesNotificationService` `5.0.2`.
> 
> Regenerates `Podfile.lock` to reflect the new pod versions and checksums.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 619c3a4cd23b3919c8cf07270415100ab87c470d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->