### PR TITLE
Fix element targeting for native dialog windows on Android

### DIFF
--- a/android/src/main/java/com/appcuesreactnative/ReactNativeElementTargeting.kt
+++ b/android/src/main/java/com/appcuesreactnative/ReactNativeElementTargeting.kt
@@ -2,6 +2,7 @@ package com.appcuesreactnative
 
 import android.annotation.SuppressLint
 import android.app.Activity
+import android.content.ContextWrapper
 import android.graphics.Rect
 import android.os.Build
 import android.util.Log
@@ -74,30 +75,24 @@ internal data class ReactNativeViewSelector(
 @Suppress("UNCHECKED_CAST")
 @SuppressLint("PrivateApi")
 internal fun Activity.getParentView(): ViewGroup {
-    // try to find the most applicable decorView to inject Appcues content into. Typically there is just a single
-    // decorView on the Activity window. However, if something like a dialog modal has been shown, this can add another
-    // window with another decorView on top of the Activity. If we want to support showing content above that layer, we need
-    // to find the top most decorView like below.
+    // Try to find the most applicable decorView to capture from. Typically there is just a single
+    // decorView on the Activity window. However, if something like a dialog modal has been shown,
+    // this can add another window with another decorView on top of the Activity. We need to find
+    // the topmost decorView belonging to this activity.
     val decorView = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-        // this is the preferred method on API 29+ with the new WindowInspector function
-        // in case of multiple views, get the one that is hosting android.R.id.content
-        // we get the last one because sometimes stacking activities might be listed in this method,
-        // and we always want the one that is on top
-        WindowInspector.getGlobalWindowViews().findTopMost() ?: window.decorView
+        WindowInspector.getGlobalWindowViews().findTopMost(this) ?: window.decorView
       } else {
         @Suppress("SwallowedException", "TooGenericExceptionCaught")
         try {
-            // this is the less desirable method for API 21-28, using reflection to try to get the root views
             val windowManagerClass = Class.forName("android.view.WindowManagerGlobal")
             val windowManager = windowManagerClass.getMethod("getInstance").invoke(null)
             val getViewRootNames: Method = windowManagerClass.getMethod("getViewRootNames")
             val getRootView: Method = windowManagerClass.getMethod("getRootView", String::class.java)
             val rootViewNames = getViewRootNames.invoke(windowManager) as Array<Any?>
             val rootViews = rootViewNames.map { getRootView(windowManager, it) as View }
-            rootViews.findTopMost() ?: window.decorView
+            rootViews.findTopMost(this) ?: window.decorView
           } catch (ex: Exception) {
             Log.e("Appcues", "error getting decorView, ${ex.message}")
-            // if all else fails, use the decorView on the window, which is typically the only one
             window.decorView
           }
     }
@@ -105,7 +100,26 @@ internal fun Activity.getParentView(): ViewGroup {
     return decorView.rootView as ViewGroup
 }
 
-private fun List<View>.findTopMost() = lastOrNull { it.findViewById<View?>(android.R.id.content) != null }
+// Finds the topmost window root that is a real DecorView belonging to this activity.
+// Dialog windows wrap the activity context in ContextThemeWrapper, so we unwrap to match.
+// WindowInspector can also return non-DecorView roots (e.g. Compose PopupLayout) that
+// don't support addView — filtering by isDecorView() avoids those.
+private fun List<View>.findTopMost(activity: Activity) = lastOrNull {
+    it.isOwnedBy(activity) && it.isDecorView()
+}
+
+private fun View.isOwnedBy(activity: Activity): Boolean {
+    var ctx: android.content.Context? = context
+    while (ctx != null) {
+        if (ctx == activity) return true
+        ctx = (ctx as? ContextWrapper)?.baseContext
+    }
+    return false
+}
+
+private fun View.isDecorView(): Boolean {
+    return this::class.java.name == "com.android.internal.policy.DecorView"
+}
 
 internal class ReactNativeViewTargeting(
     private val module: AppcuesReactNativeModule

--- a/example/src/screens/main/EventsScreen.tsx
+++ b/example/src/screens/main/EventsScreen.tsx
@@ -1,5 +1,5 @@
-import { useCallback, useEffect } from 'react';
-import { StyleSheet, View } from 'react-native';
+import { useCallback, useEffect, useState } from 'react';
+import { StyleSheet, View, Modal, Text, Pressable } from 'react-native';
 import {
   useFocusEffect,
   useNavigation,
@@ -11,6 +11,7 @@ import { TintedButton, TabBarButton } from '../../components/Button';
 
 export const EventsView = () => {
   const navigation = useNavigation<NativeStackNavigationProp<ParamListBase>>();
+  const [modalVisible, setModalVisible] = useState(false);
 
   useFocusEffect(
     useCallback(() => {
@@ -39,6 +40,39 @@ export const EventsView = () => {
         testID="btnEvent2"
         onPress={() => Appcues.track('event2')}
       />
+      <TintedButton
+        title="Show Native Modal"
+        testID="btnShowModal"
+        onPress={() => setModalVisible(true)}
+      />
+
+      <Modal
+        visible={modalVisible}
+        transparent={true}
+        animationType="slide"
+        onRequestClose={() => setModalVisible(false)}
+      >
+        <View style={styles.modalOverlay}>
+          <View style={styles.modalContent}>
+            <Text style={styles.modalTitle}>Native Modal</Text>
+            <Text style={styles.modalText}>
+              This creates a separate Android Dialog window. Appcues overlays
+              and the debugger FAB should appear above this modal.
+            </Text>
+            <TintedButton
+              title="Trigger Event 1 (from modal)"
+              testID="btnEvent1Modal"
+              onPress={() => Appcues.track('event1')}
+            />
+            <Pressable
+              style={styles.closeButton}
+              onPress={() => setModalVisible(false)}
+            >
+              <Text style={styles.closeButtonText}>Close Modal</Text>
+            </Pressable>
+          </View>
+        </View>
+      </Modal>
     </View>
   );
 };
@@ -50,5 +84,38 @@ const styles = StyleSheet.create({
     paddingTop: 35,
     paddingLeft: 40,
     paddingRight: 40,
+  },
+  modalOverlay: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    backgroundColor: 'rgba(0, 0, 0, 0.5)',
+  },
+  modalContent: {
+    backgroundColor: 'white',
+    borderRadius: 16,
+    padding: 24,
+    width: '85%',
+    alignItems: 'center',
+  },
+  modalTitle: {
+    fontSize: 20,
+    fontWeight: '600',
+    marginBottom: 12,
+  },
+  modalText: {
+    fontSize: 14,
+    color: '#666',
+    textAlign: 'center',
+    marginBottom: 20,
+  },
+  closeButton: {
+    marginTop: 12,
+    paddingVertical: 10,
+    paddingHorizontal: 24,
+  },
+  closeButtonText: {
+    fontSize: 16,
+    color: '#007AFF',
   },
 });


### PR DESCRIPTION
## Summary

- Fixes element targeting/layout capture failing to traverse dialog window view hierarchies on Android
- Root cause: `findTopMost()` used `findViewById(android.R.id.content) != null` to filter window roots, but dialog windows often don't have `android.R.id.content`, so the SDK falls back to the Activity's DecorView and misses views inside the dialog
- Regression introduced in 678c882 (Feb 2024) when the filter was ported from the Android SDK's split-screen fix
- Companion PR for Android SDK: https://github.com/appcues/appcues-android-sdk/pull/708

### Changes

**`ReactNativeElementTargeting.kt`** — Replace `findViewById(android.R.id.content)` filter with `isOwnedBy(activity) && isDecorView()`. Uses `ContextWrapper` unwrap to match dialog DecorViews whose context is wrapped in `ContextThemeWrapper`. Aligns with the same fix in `appcues-android-sdk`.

**`EventsScreen.tsx`** — Added native Modal to example app Events screen for testing overlay layering with dialog windows.

## Test plan

- [x] Open RN Modal, launch debugger via deep link → debugger appears above modal
- [x] Verified regression: without fix, debugger renders behind modal
- [x] Screen capture accessible while native modal is displayed

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a native modal dialog to the events screen that allows users to trigger event tracking directly from within the modal interface. The modal includes dedicated controls for event triggering and dismissal.

* **Refactor**
  * Improved window detection logic to enhance reliability in identifying application windows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/appcues/appcues-react-native-module/pull/226?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->