### PR TITLE
Fix iOS analytics observing after refresh

### DIFF
--- a/ios/Implementation.swift
+++ b/ios/Implementation.swift
@@ -36,7 +36,16 @@ public class Implementation: NSObject {
         defer { resolve(nil) }
 
         // Fast refreshing can result in this being called multiple times which gets weird. `guard` is a quick way to shortcut that.
-        guard Implementation.implementation == nil else { return }
+        guard Implementation.implementation == nil else {
+          if analyticsDelegate.implementation == nil {
+            // Re-wire the analytics delegate so the current JS module instance
+            // receives events, even after a JS reload creates a new native module.
+            analyticsDelegate.implementation = self
+            Implementation.implementation?.analyticsDelegate = analyticsDelegate
+          }
+
+          return
+        }
 
         let config = Appcues.Config(accountID: accountID, applicationID: applicationID)
 


### PR DESCRIPTION
In the case of a hard refresh that recreates the `AppcuesReactNative` (and thus the `Implementation` swift class), the result was a new `AnalyticsDelegate`, but the guard in `setup()` returning early before the new delegate gets wired up. I've added a specific check and handling for `analyticsDelegate.implementation == nil` in the guard.

An easy way to test this is in an Expo app with `expo-dev-client`: open the developer menu and select "Reload".

This may resolve #192 which had a similar issue where the observer worked for Android but not iOS. However that issue didn't mention any refreshing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved analytics stability and reliability during repeated initialization cycles. Enhanced delegate handling ensures consistent state management and prevents potential data collection issues. The system now safely maintains and reconfigures analytics components when initialization is attempted multiple times, providing more robust behavior throughout the entire application lifecycle.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/appcues/appcues-react-native-module/pull/227?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->